### PR TITLE
confusion node_id

### DIFF
--- a/docs/commands/rpc-protocol.md
+++ b/docs/commands/rpc-protocol.md
@@ -859,7 +859,7 @@ Initialize bootstrap to specific **IP address** and **port**
 ---
 
 ### bootstrap_any  
-Initialize multi-connection bootstrap to random 
+Initialize multi-connection bootstrap to random peers
 
 **Request:**
 ```json

--- a/docs/commands/rpc-protocol.md
+++ b/docs/commands/rpc-protocol.md
@@ -859,7 +859,7 @@ Initialize bootstrap to specific **IP address** and **port**
 ---
 
 ### bootstrap_any  
-Initialize multi-connection bootstrap to random peers   
+Initialize multi-connection bootstrap to random 
 
 **Request:**
 ```json
@@ -1556,7 +1556,7 @@ Returns a list of pairs of online peer IPv6:port and its node protocol network v
 **Optional "peer_details"**
 
 _version 18.0+_   
-Boolean, false by default. Returns a list of peers IPv6:port with its node protocol network version and node ID. `type` returned in version 19.0+ as either `tcp` (preferred) or `udp` (fallback) used for peering with that node.
+Boolean, false by default. Returns a list of peers IPv6:port with its node protocol network version and node ID. The node ID is random and is not a Nano address. `type` returned in version 19.0+ as either `tcp` (preferred) or `udp` (fallback) used for peering with that node.
 
 **Response:**
 ```json


### PR DESCRIPTION
That's confusing.
FIrst a fix for the docs, but it would be better, when the ID would start with `node_` so it doesn't look like a real address.