### PR TITLE
First receive guide and other fixes

### DIFF
--- a/docs/commands/rpc-protocol.md
+++ b/docs/commands/rpc-protocol.md
@@ -21,17 +21,17 @@ Returns how many RAW is owned and how many have not yet been received by **accou
 
 **Request:**
 ```json 
-{  
-  "action": "account_balance",  
-  "account": "nano_3e3j5tkog48pnny9dmfzj1r16pg8t1e76dz5tmac6iq689wyjfpi00000000"  
+{
+  "action": "account_balance",
+  "account": "nano_3e3j5tkog48pnny9dmfzj1r16pg8t1e76dz5tmac6iq689wyjfpi00000000"
 }
 ```
 
 **Response:**
 ```json
-{  
-  "balance": "10000",  
-  "pending": "10000"  
+{
+  "balance": "10000",
+  "pending": "10000"
 }
 ```
 
@@ -42,16 +42,16 @@ Get number of blocks for a specific **account**
 
 **Request:**
 ```json
-{  
-  "action": "account_block_count",  
-  "account": "nano_3t6k35gi95xu6tergt6p69ck76ogmitsa8mnijtpxm9fkcm736xtoncuohr3"  
+{
+  "action": "account_block_count",
+  "account": "nano_3t6k35gi95xu6tergt6p69ck76ogmitsa8mnijtpxm9fkcm736xtoncuohr3"
 }
 ```
 
 **Response:**
 ```json
-{  
-  "block_count" : "19"  
+{
+  "block_count" : "19"
 }
 ```
 
@@ -62,16 +62,16 @@ Get account number for the **public key**
 
 **Request:**
 ```json
-{  
-  "action": "account_get",  
-  "key": "3068BB1CA04525BB0E416C485FE6A67FD52540227D267CC8B6E8DA958A7FA039"  
+{
+  "action": "account_get",
+  "key": "3068BB1CA04525BB0E416C485FE6A67FD52540227D267CC8B6E8DA958A7FA039"
 }
 ```
 
 **Response:**
 ```json
-{  
-  "account" : "nano_1e5aqegc1jb7qe964u4adzmcezyo6o146zb8hm6dft8tkp79za3sxwjym5rx"  
+{
+  "account" : "nano_1e5aqegc1jb7qe964u4adzmcezyo6o146zb8hm6dft8tkp79za3sxwjym5rx"
 }
 ```
 
@@ -85,29 +85,29 @@ Reports send/receive information for an account. Returns only **send & receive**
 
 **Request:**
 ```json
-{  
-  "action": "account_history",  
-  "account": "nano_1ipx847tk8o46pwxt5qjdbncjqcbwcc1rrmqnkztrfjy5k7z4imsrata9est",  
+{
+  "action": "account_history",
+  "account": "nano_1ipx847tk8o46pwxt5qjdbncjqcbwcc1rrmqnkztrfjy5k7z4imsrata9est",
   "count": "1"
 }
 ```
 
 **Response:**
 ```json
-{  
-    "account": "nano_1ipx847tk8o46pwxt5qjdbncjqcbwcc1rrmqnkztrfjy5k7z4imsrata9est",   
-    "history": [   
-        {   
-            "type": "send",   
-            "account": "nano_38ztgpejb7yrm7rr586nenkn597s3a1sqiy3m3uyqjicht7kzuhnihdk6zpz",   
-            "amount": "80000000000000000000000000000000000",   
-            "local_timestamp": "1551532723",   
-            "height": "60",   
-            "hash": "80392607E85E73CC3E94B4126F24488EBDFEB174944B890C97E8F36D89591DC5"   
-        }   
-    ],   
-    "previous": "8D3AB98B301224253750D448B4BD997132400CEDD0A8432F775724F2D9821C72"   
-}   
+{
+  "account": "nano_1ipx847tk8o46pwxt5qjdbncjqcbwcc1rrmqnkztrfjy5k7z4imsrata9est",
+  "history": [
+    {
+      "type": "send",
+      "account": "nano_38ztgpejb7yrm7rr586nenkn597s3a1sqiy3m3uyqjicht7kzuhnihdk6zpz",
+      "amount": "80000000000000000000000000000000000",
+      "local_timestamp": "1551532723",
+      "height": "60",
+      "hash": "80392607E85E73CC3E94B4126F24488EBDFEB174944B890C97E8F36D89591DC5"
+    }
+  ],
+  "previous": "8D3AB98B301224253750D448B4BD997132400CEDD0A8432F775724F2D9821C72"
+}
 ```
 
 If the `count` limit results in stopping before the end of the account chain, then the response will also contain a `previous` field (outside of the `history` field) which contains the block hash that would be next to process if `count` was larger.
@@ -129,23 +129,23 @@ Returns frontier, open block, change representative block, balance, last modifie
 
 **Request:**
 ```json
-{  
-  "action": "account_info",  
-  "account": "nano_3t6k35gi95xu6tergt6p69ck76ogmitsa8mnijtpxm9fkcm736xtoncuohr3"  
+{
+  "action": "account_info",
+  "account": "nano_3t6k35gi95xu6tergt6p69ck76ogmitsa8mnijtpxm9fkcm736xtoncuohr3"
 }
 ```
 
 **Response:**
 ```json
-{  
-    "frontier": "FF84533A571D953A596EA401FD41743AC85D04F406E76FDE4408EAED50B473C5",   
-    "open_block": "991CF190094C00F0B68E2E5F75F6BEE95A2E0BD93CEAA4A6734DB9F19B728948",   
-    "representative_block": "991CF190094C00F0B68E2E5F75F6BEE95A2E0BD93CEAA4A6734DB9F19B728948",   
-    "balance": "235580100176034320859259343606608761791",   
-    "modified_timestamp": "1501793775",   
-    "block_count": "33",   
-    "confirmation_height" : "28",
-    "account_version": "1"   
+{
+  "frontier": "FF84533A571D953A596EA401FD41743AC85D04F406E76FDE4408EAED50B473C5",
+  "open_block": "991CF190094C00F0B68E2E5F75F6BEE95A2E0BD93CEAA4A6734DB9F19B728948",
+  "representative_block": "991CF190094C00F0B68E2E5F75F6BEE95A2E0BD93CEAA4A6734DB9F19B728948",
+  "balance": "235580100176034320859259343606608761791",
+  "modified_timestamp": "1501793775",
+  "block_count": "33",
+  "confirmation_height" : "28",
+  "account_version": "1"
 }
 ```
 
@@ -157,27 +157,27 @@ Booleans, false by default. Additionally returns representative, voting weight, 
 
 **Request:**
 ```json
-{  
-  "action": "account_info",  
-  "account": "nano_3t6k35gi95xu6tergt6p69ck76ogmitsa8mnijtpxm9fkcm736xtoncuohr3",    
-  "representative": "true",  
-  "weight": "true",  
-  "pending": "true"  
+{
+  "action": "account_info",
+  "account": "nano_3t6k35gi95xu6tergt6p69ck76ogmitsa8mnijtpxm9fkcm736xtoncuohr3",
+  "representative": "true",
+  "weight": "true",
+  "pending": "true"
 }
 ```
 
 **Response:**
 ```json
-{  
-    "frontier": "FF84533A571D953A596EA401FD41743AC85D04F406E76FDE4408EAED50B473C5",   
-    "open_block": "991CF190094C00F0B68E2E5F75F6BEE95A2E0BD93CEAA4A6734DB9F19B728948",   
-    "representative_block": "991CF190094C00F0B68E2E5F75F6BEE95A2E0BD93CEAA4A6734DB9F19B728948",   
-    "balance": "235580100176034320859259343606608761791",   
-    "modified_timestamp": "1501793775",   
-    "block_count": "33",   
-    "representative": "nano_3t6k35gi95xu6tergt6p69ck76ogmitsa8mnijtpxm9fkcm736xtoncuohr3",   
-    "weight": "1105577030935649664609129644855132177",   
-    "pending": "2309370929000000000000000000000000"   
+{
+  "frontier": "FF84533A571D953A596EA401FD41743AC85D04F406E76FDE4408EAED50B473C5",
+  "open_block": "991CF190094C00F0B68E2E5F75F6BEE95A2E0BD93CEAA4A6734DB9F19B728948",
+  "representative_block": "991CF190094C00F0B68E2E5F75F6BEE95A2E0BD93CEAA4A6734DB9F19B728948",
+  "balance": "235580100176034320859259343606608761791",
+  "modified_timestamp": "1501793775",
+  "block_count": "33",
+  "representative": "nano_3t6k35gi95xu6tergt6p69ck76ogmitsa8mnijtpxm9fkcm736xtoncuohr3",
+  "weight": "1105577030935649664609129644855132177",
+  "pending": "2309370929000000000000000000000000"
 }
 ```
 
@@ -188,15 +188,15 @@ Get the public key for **account**
 
 **Request:**
 ```json
-{  
-  "action": "account_key",  
-  "account" : "nano_1e5aqegc1jb7qe964u4adzmcezyo6o146zb8hm6dft8tkp79za3sxwjym5rx"  
+{
+  "action": "account_key",
+  "account" : "nano_1e5aqegc1jb7qe964u4adzmcezyo6o146zb8hm6dft8tkp79za3sxwjym5rx"
 }
 ```  
 **Response:**
 ```json
-{  
-  "key": "3068BB1CA04525BB0E416C485FE6A67FD52540227D267CC8B6E8DA958A7FA039"  
+{
+  "key": "3068BB1CA04525BB0E416C485FE6A67FD52540227D267CC8B6E8DA958A7FA039"
 }
 ```
 
@@ -207,14 +207,14 @@ Returns the representative for **account**
 
 **Request:**
 ```json
-{  
-  "action": "account_representative",  
+{
+  "action": "account_representative",
   "account": "nano_39a73oy5ungrhxy5z5oao1xso4zo7dmgpjd4u74xcrx3r1w6rtazuouw6qfi"
 }
 ```  
 **Response:**
 ```json
-{  
+{
   "representative" : "nano_16u1uufyoig8777y6r8iqjtrw8sg8maqrm36zzcm95jmbd9i9aj5i8abr8u5"
 }
 ```
@@ -226,15 +226,15 @@ Returns the voting weight for **account**
 
 **Request:**
 ```json
-{  
-  "action": "account_weight",  
-  "account": "nano_3e3j5tkog48pnny9dmfzj1r16pg8t1e76dz5tmac6iq689wyjfpi00000000"  
+{
+  "action": "account_weight",
+  "account": "nano_3e3j5tkog48pnny9dmfzj1r16pg8t1e76dz5tmac6iq689wyjfpi00000000"
 }
 ```  
 **Response:**
 ```json
-{  
-  "weight": "10000"  
+{
+  "weight": "10000"
 }
 ```
 
@@ -247,26 +247,26 @@ Returns how many RAW is owned and how many have not yet been received by **accou
 
 **Request:**
 ```json
-{  
-  "action": "accounts_balances",  
-  "accounts": ["nano_3e3j5tkog48pnny9dmfzj1r16pg8t1e76dz5tmac6iq689wyjfpi00000000", "nano_3i1aq1cchnmbn9x5rsbap8b15akfh7wj7pwskuzi7ahz8oq6cobd99d4r3b7"]  
+{
+  "action": "accounts_balances",
+  "accounts": ["nano_3e3j5tkog48pnny9dmfzj1r16pg8t1e76dz5tmac6iq689wyjfpi00000000", "nano_3i1aq1cchnmbn9x5rsbap8b15akfh7wj7pwskuzi7ahz8oq6cobd99d4r3b7"]
 }
 ```  
 **Response:**
 ```json
-{  
-  "balances" : {  
-    "nano_3e3j5tkog48pnny9dmfzj1r16pg8t1e76dz5tmac6iq689wyjfpi00000000":  
-    {  
-      "balance": "10000",  
-      "pending": "10000"  
-    },  
-    "nano_3i1aq1cchnmbn9x5rsbap8b15akfh7wj7pwskuzi7ahz8oq6cobd99d4r3b7":  
-    {  
-      "balance": "10000000",  
-      "pending": "0"  
-    }  
-  }  
+{
+  "balances" : {
+    "nano_3e3j5tkog48pnny9dmfzj1r16pg8t1e76dz5tmac6iq689wyjfpi00000000":
+    {
+      "balance": "10000",
+      "pending": "10000"
+    },
+    "nano_3i1aq1cchnmbn9x5rsbap8b15akfh7wj7pwskuzi7ahz8oq6cobd99d4r3b7":
+    {
+      "balance": "10000000",
+      "pending": "0"
+    }
+  }
 }
 ```  
 
@@ -277,18 +277,18 @@ Returns a list of pairs of account and block hash representing the head block fo
 
 **Request:**
 ```json
-{  
-  "action": "accounts_frontiers",  
-  "accounts": ["nano_3t6k35gi95xu6tergt6p69ck76ogmitsa8mnijtpxm9fkcm736xtoncuohr3", "nano_3i1aq1cchnmbn9x5rsbap8b15akfh7wj7pwskuzi7ahz8oq6cobd99d4r3b7"]  
+{
+  "action": "accounts_frontiers",
+  "accounts": ["nano_3t6k35gi95xu6tergt6p69ck76ogmitsa8mnijtpxm9fkcm736xtoncuohr3", "nano_3i1aq1cchnmbn9x5rsbap8b15akfh7wj7pwskuzi7ahz8oq6cobd99d4r3b7"]
 }
 ```  
 **Response:**
 ```json
-{  
-  "frontiers" : {  
-    "nano_3t6k35gi95xu6tergt6p69ck76ogmitsa8mnijtpxm9fkcm736xtoncuohr3": "791AF413173EEE674A6FCF633B5DFC0F3C33F397F0DA08E987D9E0741D40D81A",  
-    "nano_3i1aq1cchnmbn9x5rsbap8b15akfh7wj7pwskuzi7ahz8oq6cobd99d4r3b7": "6A32397F4E95AF025DE29D9BF1ACE864D5404362258E06489FABDBA9DCCC046F"  
-  }  
+{
+  "frontiers" : {
+    "nano_3t6k35gi95xu6tergt6p69ck76ogmitsa8mnijtpxm9fkcm736xtoncuohr3": "791AF413173EEE674A6FCF633B5DFC0F3C33F397F0DA08E987D9E0741D40D81A",
+    "nano_3i1aq1cchnmbn9x5rsbap8b15akfh7wj7pwskuzi7ahz8oq6cobd99d4r3b7": "6A32397F4E95AF025DE29D9BF1ACE864D5404362258E06489FABDBA9DCCC046F"
+  }
 }
 ```  
 
@@ -299,19 +299,19 @@ Returns a list of block hashes which have not yet been received by these **accou
 
 **Request:**
 ```json
-{  
-  "action": "accounts_pending",  
-  "accounts": ["nano_1111111111111111111111111111111111111111111111111117353trpda", "nano_3t6k35gi95xu6tergt6p69ck76ogmitsa8mnijtpxm9fkcm736xtoncuohr3"],  
+{
+  "action": "accounts_pending",
+  "accounts": ["nano_1111111111111111111111111111111111111111111111111117353trpda", "nano_3t6k35gi95xu6tergt6p69ck76ogmitsa8mnijtpxm9fkcm736xtoncuohr3"],
   "count": "1"
 }
 ```  
 **Response:**
 ```json
-{  
-  "blocks" : {  
-    "nano_1111111111111111111111111111111111111111111111111117353trpda": ["142A538F36833D1CC78B94E11C766F75818F8B940771335C6C1B8AB880C5BB1D"],  
-    "nano_3t6k35gi95xu6tergt6p69ck76ogmitsa8mnijtpxm9fkcm736xtoncuohr3": ["4C1FEEF0BEA7F50BE35489A1233FE002B212DEA554B55B1B470D78BD8F210C74"]  
-  }  
+{
+  "blocks" : {
+    "nano_1111111111111111111111111111111111111111111111111117353trpda": ["142A538F36833D1CC78B94E11C766F75818F8B940771335C6C1B8AB880C5BB1D"],
+    "nano_3t6k35gi95xu6tergt6p69ck76ogmitsa8mnijtpxm9fkcm736xtoncuohr3": ["4C1FEEF0BEA7F50BE35489A1233FE002B212DEA554B55B1B470D78BD8F210C74"]
+  }
 }
 ```  
 **Optional "threshold"**  
@@ -320,23 +320,24 @@ Number (128 bit, decimal). Returns a list of pending block hashes with amount mo
 
 **Request:**
 ```json
-{  
-  "action": "accounts_pending",  
-  "accounts": ["nano_1111111111111111111111111111111111111111111111111117353trpda", "nano_3t6k35gi95xu6tergt6p69ck76ogmitsa8mnijtpxm9fkcm736xtoncuohr3"],  
-  "count": "1",  
-  "threshold": "1000000000000000000000000"   
+{
+  "action": "accounts_pending",
+  "accounts": ["nano_1111111111111111111111111111111111111111111111111117353trpda", "nano_3t6k35gi95xu6tergt6p69ck76ogmitsa8mnijtpxm9fkcm736xtoncuohr3"],
+  "count": "1",
+  "threshold": "1000000000000000000000000"
 }
 ```  
 **Response:**
 ```json
-{  
+{
   "blocks" : {
-    "nano_1111111111111111111111111111111111111111111111111117353trpda": {    
-        "142A538F36833D1CC78B94E11C766F75818F8B940771335C6C1B8AB880C5BB1D": "6000000000000000000000000000000"    
-    },    
-    "nano_3t6k35gi95xu6tergt6p69ck76ogmitsa8mnijtpxm9fkcm736xtoncuohr3": {    
-        "4C1FEEF0BEA7F50BE35489A1233FE002B212DEA554B55B1B470D78BD8F210C74": "106370018000000000000000000000000"    
-    }  
+    "nano_1111111111111111111111111111111111111111111111111117353trpda": {
+      "142A538F36833D1CC78B94E11C766F75818F8B940771335C6C1B8AB880C5BB1D": "6000000000000000000000000000000"
+    },
+    "nano_3t6k35gi95xu6tergt6p69ck76ogmitsa8mnijtpxm9fkcm736xtoncuohr3": {
+      "4C1FEEF0BEA7F50BE35489A1233FE002B212DEA554B55B1B470D78BD8F210C74": "106370018000000000000000000000000"
+    }
+  }
 }
 ```  
 **Optional "source"**  
@@ -345,29 +346,30 @@ Boolean, false by default. Returns a list of pending block hashes with amount an
 
 **Request:**
 ```json
-{  
-  "action": "accounts_pending",  
-  "accounts": ["nano_1111111111111111111111111111111111111111111111111117353trpda", "nano_3t6k35gi95xu6tergt6p69ck76ogmitsa8mnijtpxm9fkcm736xtoncuohr3"],  
-  "count": "1",  
-  "source": "true"   
+{
+  "action": "accounts_pending",
+  "accounts": ["nano_1111111111111111111111111111111111111111111111111117353trpda", "nano_3t6k35gi95xu6tergt6p69ck76ogmitsa8mnijtpxm9fkcm736xtoncuohr3"],
+  "count": "1",
+  "source": "true"
 }
 ```  
 **Response:**
 ```json
-{  
+{
   "blocks" : {
-    "nano_1111111111111111111111111111111111111111111111111117353trpda": {    
-        "142A538F36833D1CC78B94E11C766F75818F8B940771335C6C1B8AB880C5BB1D": {   
-             "amount": "6000000000000000000000000000000",       
-             "source": "nano_3dcfozsmekr1tr9skf1oa5wbgmxt81qepfdnt7zicq5x3hk65fg4fqj58mbr"
-        }
-    },    
-    "nano_3t6k35gi95xu6tergt6p69ck76ogmitsa8mnijtpxm9fkcm736xtoncuohr3": {    
-        "4C1FEEF0BEA7F50BE35489A1233FE002B212DEA554B55B1B470D78BD8F210C74": {   
-             "amount": "106370018000000000000000000000000",       
-             "source": "nano_13ezf4od79h1tgj9aiu4djzcmmguendtjfuhwfukhuucboua8cpoihmh8byo"
-        }   
-    }  
+    "nano_1111111111111111111111111111111111111111111111111117353trpda": {
+      "142A538F36833D1CC78B94E11C766F75818F8B940771335C6C1B8AB880C5BB1D": {
+        "amount": "6000000000000000000000000000000",
+        "source": "nano_3dcfozsmekr1tr9skf1oa5wbgmxt81qepfdnt7zicq5x3hk65fg4fqj58mbr"
+      }
+    },
+    "nano_3t6k35gi95xu6tergt6p69ck76ogmitsa8mnijtpxm9fkcm736xtoncuohr3": {
+      "4C1FEEF0BEA7F50BE35489A1233FE002B212DEA554B55B1B470D78BD8F210C74": {
+        "amount": "106370018000000000000000000000000",
+        "source": "nano_13ezf4od79h1tgj9aiu4djzcmmguendtjfuhwfukhuucboua8cpoihmh8byo"
+      }
+    }
+  }
 }
 ```  
 **Optional "include_active"**
@@ -377,11 +379,11 @@ Boolean, false by default. Include active (not confirmed) blocks
 
 **Request:**
 ```json
-{  
-  "action": "accounts_pending",  
-  "accounts": ["nano_1111111111111111111111111111111111111111111111111117353trpda", "nano_3t6k35gi95xu6tergt6p69ck76ogmitsa8mnijtpxm9fkcm736xtoncuohr3"],  
-  "count": "1",  
-  "include_active": "true"   
+{
+  "action": "accounts_pending",
+  "accounts": ["nano_1111111111111111111111111111111111111111111111111117353trpda", "nano_3t6k35gi95xu6tergt6p69ck76ogmitsa8mnijtpxm9fkcm736xtoncuohr3"],
+  "count": "1",
+  "include_active": "true"
 }
 ```  
 
@@ -404,17 +406,17 @@ Returns the difficulty values (16 hexadecimal digits string, 64 bit) for the min
 
 **Request:**
 ```json
-{  
-  "action": "active_difficulty"  
+{
+  "action": "active_difficulty"
 }
 ```  
 
 **Response:**
 ```json
 {
-    "network_minimum": "ffffffc000000000",
-    "network_current": "ffffffcdbf40aa45",
-    "multiplier": "1.273557846739298"
+  "network_minimum": "ffffffc000000000",
+  "network_current": "ffffffcdbf40aa45",
+  "multiplier": "1.273557846739298"
 }
 ```
 
@@ -424,7 +426,7 @@ Boolean, false by default. Also returns the trend of difficulty seen on the netw
 
 **Request:**
 ```json
-{  
+{
   "action": "active_difficulty",
   "include_trend": "true"
 }
@@ -433,17 +435,17 @@ Boolean, false by default. Also returns the trend of difficulty seen on the netw
 **Response:**
 ```json
 {
-    "network_minimum": "ffffffc000000000",
-    "network_current": "ffffffc1816766f2",
-    "multiplier": "1.024089858417128",
-    "difficulty_trend": [
-        "1.156096135149775",
-        "1.190133894573061",
-        "1.135567138563921",
-        "1.000000000000000",
-        "...skipped...",
-        "1.000000000000000"
-    ]
+  "network_minimum": "ffffffc000000000",
+  "network_current": "ffffffc1816766f2",
+  "multiplier": "1.024089858417128",
+  "difficulty_trend": [
+    "1.156096135149775",
+    "1.190133894573061",
+    "1.135567138563921",
+    "1.000000000000000",
+    "...",
+    "1.000000000000000"
+  ]
 }
 ```
 
@@ -454,14 +456,14 @@ Returns how many raw are in the public supply
 
 **Request:**
 ```json
-{  
-  "action": "available_supply"  
+{
+  "action": "available_supply"
 }
 ```  
 **Response:**
 ```json
-{  
-  "available": "133248061996216572282917317807824970865"  
+{
+  "available": "133248061996216572282917317807824970865"
 }
 ```
 
@@ -472,15 +474,15 @@ Returns the account containing block
 
 **Request:**
 ```json
-{  
-  "action": "block_account",  
-  "hash": "000D1BAEC8EC208142C99059B393051BAC8380F9B5A2E6B2489A277D81789F3F"  
+{
+  "action": "block_account",
+  "hash": "000D1BAEC8EC208142C99059B393051BAC8380F9B5A2E6B2489A277D81789F3F"
 }
 ```  
 **Response:**
 ```json
-{  
-  "account": "nano_3e3j5tkog48pnny9dmfzj1r16pg8t1e76dz5tmac6iq689wyjfpi00000000"  
+{
+  "account": "nano_3e3j5tkog48pnny9dmfzj1r16pg8t1e76dz5tmac6iq689wyjfpi00000000"
 }
 ```
 
@@ -492,15 +494,15 @@ Request confirmation for **block** from known online representative nodes. Check
 
 **Request:**
 ```json
-{  
-  "action": "block_confirm",  
-  "hash": "000D1BAEC8EC208142C99059B393051BAC8380F9B5A2E6B2489A277D81789F3F"  
+{
+  "action": "block_confirm",
+  "hash": "000D1BAEC8EC208142C99059B393051BAC8380F9B5A2E6B2489A277D81789F3F"
 }
 ```  
 **Response:**
 ```json
-{  
-  "started": "1"  
+{
+  "started": "1"
 }
 ```
 
@@ -511,15 +513,15 @@ Reports the number of blocks in the ledger and unchecked synchronizing blocks
 
 **Request:**
 ```json
-{  
-  "action": "block_count"  
+{
+  "action": "block_count"
 }
 ```  
 **Response:**
 ```json
 {
-  "count": "1000",  
-  "unchecked": "10"  
+  "count": "1000",
+  "unchecked": "10"
 }
 ```
 **Optional "include_cemented"**
@@ -534,20 +536,20 @@ Reports the number of blocks in the ledger by type (send, receive, open, change,
 
 **Request:**
 ```json
-{  
-  "action": "block_count_type"  
+{
+  "action": "block_count_type"
 }
 ```  
 **Response:**
 ```json
 {
-    "send": "5016664",
-    "receive": "4081228",
-    "open": "546457",
-    "change": "24193",
-    "state_v0": "4216537",
-    "state_v1": "10653709",
-    "state": "14870246"
+  "send": "5016664",
+  "receive": "4081228",
+  "open": "546457",
+  "change": "24193",
+  "state_v0": "4216537",
+  "state_v1": "10653709",
+  "state": "14870246"
 }
 ```  
 
@@ -555,19 +557,20 @@ Reports the number of blocks in the ledger by type (send, receive, open, change,
 
 ### block_create
 _enable_control required, version 9.0+_  
-Creates a json representations of new block based on input data & signed with **private key** or **account** in **wallet**. Use for offline signing.  
-   
+Creates a json representations of new block based on input data & signed with **private key** or **account** in **wallet**. Use for offline signing. Using the optional `json_block` is recommended since v19.0.  
+
 
 **Request sample for state block:**  
 ```json
-{  
-  "action": "block_create",   
-  "type": "state",   
-  "balance": "1000000000000000000000",   
-  "key": "0000000000000000000000000000000000000000000000000000000000000002",   
-  "representative": "nano_1hza3f7wiiqa7ig3jczyxj5yo86yegcmqk3criaz838j91sxcckpfhbhhra1",   
-  "link": "19D3D919475DEED4696B5D13018151D1AF88B2BD3BCFF048B45031C1F36D1858",   
-  "previous": "F47B23107E5F34B2CE06F562B5C435DF72A533251CB414C51B2B62A8F63A00E4"   
+{
+  "action": "block_create",
+  "json_block": "true",
+  "type": "state",
+  "balance": "1000000000000000000000",
+  "key": "0000000000000000000000000000000000000000000000000000000000000002",
+  "representative": "nano_1hza3f7wiiqa7ig3jczyxj5yo86yegcmqk3criaz838j91sxcckpfhbhhra1",
+  "link": "19D3D919475DEED4696B5D13018151D1AF88B2BD3BCFF048B45031C1F36D1858",
+  "previous": "F47B23107E5F34B2CE06F562B5C435DF72A533251CB414C51B2B62A8F63A00E4"
 }
 ```  
 Parameters for state block:
@@ -591,21 +594,21 @@ Default "false". If "true", "block" in the response will contain a JSON subtree 
 
 **Examples**
 
-**Response sample for state block**:  
+**Response sample for above request**:  
 ```json
-{  
-   "hash": "FF0144381CFF0B2C079A115E7ADA7E96F43FD219446E7524C48D1CC9900C4F17",   
-   "block": "{\n    
-      \"type\": \"state\",\n    
-      \"account\": \"nano_3qgmh14nwztqw4wmcdzy4xpqeejey68chx6nciczwn9abji7ihhum9qtpmdr\",\n    
-      \"previous\": \"F47B23107E5F34B2CE06F562B5C435DF72A533251CB414C51B2B62A8F63A00E4\",\n    
-      \"representative\": \"nano_1hza3f7wiiqa7ig3jczyxj5yo86yegcmqk3criaz838j91sxcckpfhbhhra1\",\n    
-      \"balance\": \"1000000000000000000000\",\n    
-      \"link\": \"19D3D919475DEED4696B5D13018151D1AF88B2BD3BCFF048B45031C1F36D1858\",\n    
-      \"link_as_account\": \"nano_18gmu6engqhgtjnppqam181o5nfhj4sdtgyhy36dan3jr9spt84rzwmktafc\",\n    
-      \"signature\": \"3BFBA64A775550E6D49DF1EB8EEC2136DCD74F090E2ED658FBD9E80F17CB1C9F9F7BDE2B93D95558EC2F277FFF15FD11E6E2162A1714731B743D1E941FA4560A\",\n    
-      \"work\": \"cab7404f0b5449d0\"\n
-   }\n"
+{
+  "hash": "FF0144381CFF0B2C079A115E7ADA7E96F43FD219446E7524C48D1CC9900C4F17",
+  "block": {
+    "type": "state",
+    "account": "nano_3qgmh14nwztqw4wmcdzy4xpqeejey68chx6nciczwn9abji7ihhum9qtpmdr",
+    "previous": "F47B23107E5F34B2CE06F562B5C435DF72A533251CB414C51B2B62A8F63A00E4",
+    "representative": "nano_1hza3f7wiiqa7ig3jczyxj5yo86yegcmqk3criaz838j91sxcckpfhbhhra1",
+    "balance": "1000000000000000000000",
+    "link": "19D3D919475DEED4696B5D13018151D1AF88B2BD3BCFF048B45031C1F36D1858",
+    "link_as_account": "nano_18gmu6engqhgtjnppqam181o5nfhj4sdtgyhy36dan3jr9spt84rzwmktafc",
+    "signature": "3BFBA64A775550E6D49DF1EB8EEC2136DCD74F090E2ED658FBD9E80F17CB1C9F9F7BDE2B93D95558EC2F277FFF15FD11E6E2162A1714731B743D1E941FA4560A",
+    "work": "cab7404f0b5449d0"
+  }
 }
 ```  
  
@@ -617,29 +620,30 @@ Work value (16 hexadecimal digits string, 64 bit). Uses **work** value for block
 
 ### block_hash  
 _version 13.0+_   
-Returning block hash for given **block** content   
+Returning block hash for given **block** content. Using the optional `json_block` is recommended since v19.0.  
 
 **Request:**
 ```json
 {  
-  "action": "block_hash",     
-  "block": "{\n    
-      \"type\": \"state\",\n    
-      \"account\": \"nano_3qgmh14nwztqw4wmcdzy4xpqeejey68chx6nciczwn9abji7ihhum9qtpmdr\",\n    
-      \"previous\": \"F47B23107E5F34B2CE06F562B5C435DF72A533251CB414C51B2B62A8F63A00E4\",\n    
-      \"representative\": \"nano_1hza3f7wiiqa7ig3jczyxj5yo86yegcmqk3criaz838j91sxcckpfhbhhra1\",\n    
-      \"balance\": \"1000000000000000000000\",\n    
-      \"link\": \"19D3D919475DEED4696B5D13018151D1AF88B2BD3BCFF048B45031C1F36D1858\",\n    
-      \"link_as_account\": \"nano_18gmu6engqhgtjnppqam181o5nfhj4sdtgyhy36dan3jr9spt84rzwmktafc\",\n    
-      \"signature\": \"3BFBA64A775550E6D49DF1EB8EEC2136DCD74F090E2ED658FBD9E80F17CB1C9F9F7BDE2B93D95558EC2F277FFF15FD11E6E2162A1714731B743D1E941FA4560A\",\n    
-      \"work\": \"cab7404f0b5449d0\"\n
-   }\n"
+  "action": "block_hash",
+  "json_block": "true", 
+  "block": {
+    "type": "state",
+    "account": "nano_3qgmh14nwztqw4wmcdzy4xpqeejey68chx6nciczwn9abji7ihhum9qtpmdr",
+    "previous": "F47B23107E5F34B2CE06F562B5C435DF72A533251CB414C51B2B62A8F63A00E4",
+    "representative": "nano_1hza3f7wiiqa7ig3jczyxj5yo86yegcmqk3criaz838j91sxcckpfhbhhra1",
+    "balance": "1000000000000000000000",
+    "link": "19D3D919475DEED4696B5D13018151D1AF88B2BD3BCFF048B45031C1F36D1858",
+    "link_as_account": "nano_18gmu6engqhgtjnppqam181o5nfhj4sdtgyhy36dan3jr9spt84rzwmktafc",
+    "signature": "3BFBA64A775550E6D49DF1EB8EEC2136DCD74F090E2ED658FBD9E80F17CB1C9F9F7BDE2B93D95558EC2F277FFF15FD11E6E2162A1714731B743D1E941FA4560A",
+    "work": "cab7404f0b5449d0"
+  }
 }
 ```  
 **Response:**
 ```json
 {
-   "hash": "FF0144381CFF0B2C079A115E7ADA7E96F43FD219446E7524C48D1CC9900C4F17"   
+  "hash": "FF0144381CFF0B2C079A115E7ADA7E96F43FD219446E7524C48D1CC9900C4F17"
 }
 ```
 
@@ -656,34 +660,37 @@ Retrieves a json representation of the block in `contents` along with:
 * _since version 18.0_: `block_account`, transaction `amount`, block `balance`, block `height` in account chain, block local modification `timestamp`
 * _since version 19.0_: Whether block was `confirmed`, `subtype` (_for state blocks_) of `send`, `receive`, `change` or `epoch`
 
+Using the optional `json_block` is recommended since v19.0.  
+
 **Request:**
 ```json
 {  
-  "action": "block_info",  
-  "hash": "87434F8041869A01C8F6F263B87972D7BA443A72E0A97D7A3FD0CCC2358FD6F9"  
+  "action": "block_info",
+  "json_block": "true",
+  "hash": "87434F8041869A01C8F6F263B87972D7BA443A72E0A97D7A3FD0CCC2358FD6F9"
 }
 ```  
 **Response:**
 ```json
-{  
-  "block_account": "nano_1ipx847tk8o46pwxt5qjdbncjqcbwcc1rrmqnkztrfjy5k7z4imsrata9est",  
-  "amount": "30000000000000000000000000000000000",  
-  "balance": "5606157000000000000000000000000000000",  
-  "height": "58",  
-  "local_timestamp": "0",  
-  "confirmed": "false",  
-  "contents" : "{\n    
-      \"type\": \"state\",\n
-      \"account\": \"nano_1ipx847tk8o46pwxt5qjdbncjqcbwcc1rrmqnkztrfjy5k7z4imsrata9est\",\n    
-      \"previous\": \"CE898C131AAEE25E05362F247760F8A3ACF34A9796A5AE0D9204E86B0637965E\",\n    
-      \"representative\": \"nano_1stofnrxuz3cai7ze75o174bpm7scwj9jn3nxsn8ntzg784jf1gzn1jjdkou\",\n    
-      \"balance\": \"5606157000000000000000000000000000000\",\n    
-      \"link\": \"5D1AA8A45F8736519D707FCB375976A7F9AF795091021D7E9C7548D6F45DD8D5\",\n    
-      \"link_as_account\": \"nano_1qato4k7z3spc8gq1zyd8xeqfbzsoxwo36a45ozbrxcatut7up8ohyardu1z\",\n    
-      \"signature\": \"82D41BC16F313E4B2243D14DFFA2FB04679C540C2095FEE7EAE0F2F26880AD56DD48D87A7CC5DD760C5B2D76EE2C205506AA557BF00B60D8DEE312EC7343A501\",\n    
-      \"work\": \"8a142e07a10996d5\"\n    
-   }\n",  
-   "subtype": "send"  
+{
+  "block_account": "nano_1ipx847tk8o46pwxt5qjdbncjqcbwcc1rrmqnkztrfjy5k7z4imsrata9est",
+  "amount": "30000000000000000000000000000000000",
+  "balance": "5606157000000000000000000000000000000",
+  "height": "58",
+  "local_timestamp": "0",
+  "confirmed": "true",
+  "contents": {
+    "type": "state",
+    "account": "nano_1ipx847tk8o46pwxt5qjdbncjqcbwcc1rrmqnkztrfjy5k7z4imsrata9est",
+    "previous": "CE898C131AAEE25E05362F247760F8A3ACF34A9796A5AE0D9204E86B0637965E",
+    "representative": "nano_1stofnrxuz3cai7ze75o174bpm7scwj9jn3nxsn8ntzg784jf1gzn1jjdkou",
+    "balance": "5606157000000000000000000000000000000",
+    "link": "5D1AA8A45F8736519D707FCB375976A7F9AF795091021D7E9C7548D6F45DD8D5",
+    "link_as_account": "nano_1qato4k7z3spc8gq1zyd8xeqfbzsoxwo36a45ozbrxcatut7up8ohyardu1z",
+    "signature": "82D41BC16F313E4B2243D14DFFA2FB04679C540C2095FEE7EAE0F2F26880AD56DD48D87A7CC5DD760C5B2D76EE2C205506AA557BF00B60D8DEE312EC7343A501",
+    "work": "8a142e07a10996d5"
+  },
+  "subtype": "send"
 }
 ```
 
@@ -697,33 +704,39 @@ Default "false". If "true", "contents" will contain a JSON subtree instead of a 
 ---
 
 ### blocks  
-Retrieves a json representations of **blocks**  
+Retrieves a json representations of **blocks**. Using the optional `json_block` is recommended since v19.0.  
 
 **Request:**
 ```json
-{  
-  "action": "blocks",  
-  "hashes": ["87434F8041869A01C8F6F263B87972D7BA443A72E0A97D7A3FD0CCC2358FD6F9"]  
+{
+  "action": "blocks",
+  "json_block": "true",
+  "hashes": ["87434F8041869A01C8F6F263B87972D7BA443A72E0A97D7A3FD0CCC2358FD6F9"]
 }
 ```  
 **Response:**
 ```json
-{  
-  "blocks" : {  
-    "87434F8041869A01C8F6F263B87972D7BA443A72E0A97D7A3FD0CCC2358FD6F9": "{\n    
-       \"type\": \"state\",\n
-       \"account\": \"nano_1ipx847tk8o46pwxt5qjdbncjqcbwcc1rrmqnkztrfjy5k7z4imsrata9est\",\n    
-       \"previous\": \"CE898C131AAEE25E05362F247760F8A3ACF34A9796A5AE0D9204E86B0637965E\",\n    
-       \"representative\": \"nano_1stofnrxuz3cai7ze75o174bpm7scwj9jn3nxsn8ntzg784jf1gzn1jjdkou\",\n    
-       \"balance\": \"5606157000000000000000000000000000000\",\n    
-       \"link\": \"5D1AA8A45F8736519D707FCB375976A7F9AF795091021D7E9C7548D6F45DD8D5\",\n    
-       \"link_as_account\": \"nano_1qato4k7z3spc8gq1zyd8xeqfbzsoxwo36a45ozbrxcatut7up8ohyardu1z\",\n    
-       \"signature\": \"82D41BC16F313E4B2243D14DFFA2FB04679C540C2095FEE7EAE0F2F26880AD56DD48D87A7CC5DD760C5B2D76EE2C205506AA557BF00B60D8DEE312EC7343A501\",\n    
-       \"work\": \"8a142e07a10996d5\"\n    
-    }\n"
+{
+  "blocks": {
+    "87434F8041869A01C8F6F263B87972D7BA443A72E0A97D7A3FD0CCC2358FD6F9": {
+      "type": "state",
+      "account": "nano_1ipx847tk8o46pwxt5qjdbncjqcbwcc1rrmqnkztrfjy5k7z4imsrata9est",
+      "previous": "CE898C131AAEE25E05362F247760F8A3ACF34A9796A5AE0D9204E86B0637965E",
+      "representative": "nano_1stofnrxuz3cai7ze75o174bpm7scwj9jn3nxsn8ntzg784jf1gzn1jjdkou",
+      "balance": "5606157000000000000000000000000000000",
+      "link": "5D1AA8A45F8736519D707FCB375976A7F9AF795091021D7E9C7548D6F45DD8D5",
+      "link_as_account": "nano_1qato4k7z3spc8gq1zyd8xeqfbzsoxwo36a45ozbrxcatut7up8ohyardu1z",
+      "signature": "82D41BC16F313E4B2243D14DFFA2FB04679C540C2095FEE7EAE0F2F26880AD56DD48D87A7CC5DD760C5B2D76EE2C205506AA557BF00B60D8DEE312EC7343A501",
+      "work": "8a142e07a10996d5"
+    }
   }
 }
 ```
+
+**Optional "json_block"**
+
+_version 19.0+_  
+Default "false". If "true", "contents" will contain a JSON subtree instead of a JSON string.
 
 ---
 
@@ -733,37 +746,40 @@ Retrieves a json representations of `blocks` in `contents` along with:
 * _since version 18.0_: `block_account`, transaction `amount`, block `balance`, block `height` in account chain, block local modification `timestamp`
 * _since version 19.0_: Whether block was `confirmed`, `subtype` (_for state blocks_) of `send`, `receive`, `change` or `epoch`
 
+Using the optional `json_block` is recommended since v19.0.  
+
 **Request:**
 ```json
-{  
-  "action": "blocks_info",  
-  "hashes": ["87434F8041869A01C8F6F263B87972D7BA443A72E0A97D7A3FD0CCC2358FD6F9"]  
+{
+  "action": "blocks_info",
+  "json_block": "true",
+  "hashes": ["87434F8041869A01C8F6F263B87972D7BA443A72E0A97D7A3FD0CCC2358FD6F9"]
 }
 ```  
 **Response:**
 ```json
-{  
-  "blocks" : {   
-    "87434F8041869A01C8F6F263B87972D7BA443A72E0A97D7A3FD0CCC2358FD6F9": {   
-         "block_account": "nano_1ipx847tk8o46pwxt5qjdbncjqcbwcc1rrmqnkztrfjy5k7z4imsrata9est",  
-         "amount": "30000000000000000000000000000000000",  
-         "balance": "5606157000000000000000000000000000000",  
-         "height": "58",  
-         "local_timestamp": "0",  
-         "confirmed": "false",  
-       "contents": "{\n    
-         \"type\": \"state\",\n
-         \"account\": \"nano_1ipx847tk8o46pwxt5qjdbncjqcbwcc1rrmqnkztrfjy5k7z4imsrata9est\",\n    
-         \"previous\": \"CE898C131AAEE25E05362F247760F8A3ACF34A9796A5AE0D9204E86B0637965E\",\n    
-         \"representative\": \"nano_1stofnrxuz3cai7ze75o174bpm7scwj9jn3nxsn8ntzg784jf1gzn1jjdkou\",\n    
-         \"balance\": \"5606157000000000000000000000000000000\",\n    
-         \"link\": \"5D1AA8A45F8736519D707FCB375976A7F9AF795091021D7E9C7548D6F45DD8D5\",\n    
-         \"link_as_account\": \"nano_1qato4k7z3spc8gq1zyd8xeqfbzsoxwo36a45ozbrxcatut7up8ohyardu1z\",\n    
-         \"signature\": \"82D41BC16F313E4B2243D14DFFA2FB04679C540C2095FEE7EAE0F2F26880AD56DD48D87A7CC5DD760C5B2D76EE2C205506AA557BF00B60D8DEE312EC7343A501\",\n    
-         \"work\": \"8a142e07a10996d5\"\n    
-      }\n",  
-      "subtype": "send"  
-     }
+{
+  "blocks": {
+    "87434F8041869A01C8F6F263B87972D7BA443A72E0A97D7A3FD0CCC2358FD6F9": {
+      "block_account": "nano_1ipx847tk8o46pwxt5qjdbncjqcbwcc1rrmqnkztrfjy5k7z4imsrata9est",
+      "amount": "30000000000000000000000000000000000",
+      "balance": "5606157000000000000000000000000000000",
+      "height": "58",
+      "local_timestamp": "0",
+      "confirmed": "true",
+      "contents": {
+        "type": "state",
+        "account": "nano_1ipx847tk8o46pwxt5qjdbncjqcbwcc1rrmqnkztrfjy5k7z4imsrata9est",
+        "previous": "CE898C131AAEE25E05362F247760F8A3ACF34A9796A5AE0D9204E86B0637965E",
+        "representative": "nano_1stofnrxuz3cai7ze75o174bpm7scwj9jn3nxsn8ntzg784jf1gzn1jjdkou",
+        "balance": "5606157000000000000000000000000000000",
+        "link": "5D1AA8A45F8736519D707FCB375976A7F9AF795091021D7E9C7548D6F45DD8D5",
+        "link_as_account": "nano_1qato4k7z3spc8gq1zyd8xeqfbzsoxwo36a45ozbrxcatut7up8ohyardu1z",
+        "signature": "82D41BC16F313E4B2243D14DFFA2FB04679C540C2095FEE7EAE0F2F26880AD56DD48D87A7CC5DD760C5B2D76EE2C205506AA557BF00B60D8DEE312EC7343A501",
+        "work": "8a142e07a10996d5"
+      },
+      "subtype": "send"
+    }
   }
 }
 ```
@@ -775,8 +791,8 @@ Booleans, false by default. Additionally checks if block is pending, returns sou
 
 **Request:**
 ```json
-{  
-  "action": "blocks_info",  
+{
+  "action": "blocks_info",
   "hashes": ["E2FB233EF4554077A7BF1AA85851D5BF0B36965D2B0FB504B2BC778AB89917D3"],
   "pending": "true",
   "source": "true",
@@ -785,16 +801,18 @@ Booleans, false by default. Additionally checks if block is pending, returns sou
 ```  
 **Response:**
 ```json
-{  
-  "blocks" : {   
-    "E2FB233EF4554077A7BF1AA85851D5BF0B36965D2B0FB504B2BC778AB89917D3": {   
-       "block_account": "nano_1qato4k7z3spc8gq1zyd8xeqfbzsoxwo36a45ozbrxcatut7up8ohyardu1z",   
-       "amount": "30000000000000000000000000000000000",   
-       "contents": "{ ...skipped... }",
-       "pending": "0",
-       "source_account": "nano_1ipx847tk8o46pwxt5qjdbncjqcbwcc1rrmqnkztrfjy5k7z4imsrata9est",
-       "balance": "40200000001000000000000000000000000"
-     }
+{
+  "blocks" : {
+    "E2FB233EF4554077A7BF1AA85851D5BF0B36965D2B0FB504B2BC778AB89917D3": {
+      "block_account": "nano_1qato4k7z3spc8gq1zyd8xeqfbzsoxwo36a45ozbrxcatut7up8ohyardu1z",
+      "amount": "30000000000000000000000000000000000",
+      "contents": {
+        ...
+      },
+      "pending": "0",
+      "source_account": "nano_1ipx847tk8o46pwxt5qjdbncjqcbwcc1rrmqnkztrfjy5k7z4imsrata9est",
+      "balance": "40200000001000000000000000000000000"
+    }
   }
 }
 ```
@@ -821,14 +839,16 @@ Default "false". If "true", an additional "blocks_not_found" is provided in the 
 {
   "blocks" : {
     "87434F8041869A01C8F6F263B87972D7BA443A72E0A97D7A3FD0CCC2358FD6F9": {
-         "block_account": "nano_1ipx847tk8o46pwxt5qjdbncjqcbwcc1rrmqnkztrfjy5k7z4imsrata9est",
-         "amount": "30000000000000000000000000000000000",
-         "balance": "5606157000000000000000000000000000000",
-         "height": "58",
-         "local_timestamp": "0",
-         "confirmed": "false",
-       "contents": "{ ...skipped... }"
-     }
+      "block_account": "nano_1ipx847tk8o46pwxt5qjdbncjqcbwcc1rrmqnkztrfjy5k7z4imsrata9est",
+      "amount": "30000000000000000000000000000000000",
+      "balance": "5606157000000000000000000000000000000",
+      "height": "58",
+      "local_timestamp": "0",
+      "confirmed": "false",
+      "contents": {
+        ...
+      }
+    }
   },
   "blocks_not_found": [
     "0000000000000000000000000000000000000000000000000000000000000001"
@@ -843,16 +863,16 @@ Initialize bootstrap to specific **IP address** and **port**. Not compatible wit
 
 **Request:**
 ```json
-{  
-  "action": "bootstrap",  
-  "address": "::ffff:138.201.94.249",  
-  "port": "7075"  
+{
+  "action": "bootstrap",
+  "address": "::ffff:138.201.94.249",
+  "port": "7075"
 }
 ```  
 **Response:**
 ```json
 {
-  "success": ""  
+  "success": ""
 }
 ```
 
@@ -863,14 +883,14 @@ Initialize multi-connection bootstrap to random peers. Not compatible with launc
 
 **Request:**
 ```json
-{  
-  "action": "bootstrap_any"  
+{
+  "action": "bootstrap_any"
 }
 ```  
 **Response:**
 ```json
 {
-  "success": ""  
+  "success": ""
 }
 ```
 
@@ -882,15 +902,15 @@ Initialize lazy bootstrap with given block **hash**. Not compatible with launch 
 
 **Request:**
 ```json
-{  
-  "action": "bootstrap_lazy",  
-  "hash": "FF0144381CFF0B2C079A115E7ADA7E96F43FD219446E7524C48D1CC9900C4F17"  
+{
+  "action": "bootstrap_lazy",
+  "hash": "FF0144381CFF0B2C079A115E7ADA7E96F43FD219446E7524C48D1CC9900C4F17"
 }
 ```  
 **Response:**
 ```json
 {
-  "started": "1"  
+  "started": "1"
 }
 ```
 **Optional "force"**
@@ -908,28 +928,28 @@ Returning status of current bootstrap attempt
 
 **Request:**
 ```json
-{  
-  "action": "bootstrap_status"  
+{
+  "action": "bootstrap_status"
 }
 ```  
 **Response:**
 ```json
 {
-    "clients": "5790",   
-    "pulls": "141065",   
-    "pulling": "3",   
-    "connections": "16",   
-    "idle": "0",   
-    "target_connections": "64",   
-    "total_blocks": "536820",   
-    "lazy_mode": "true",   
-    "lazy_blocks": "423388",   
-    "lazy_state_unknown": "2",   
-    "lazy_balances": "0",   
-    "lazy_pulls": "0",   
-    "lazy_stopped": "644",   
-    "lazy_keys": "449",   
-    "lazy_key_1": "A86EB2B479AAF3CD531C8356A1FBE3CB500DFBF5BF292E5E6B8D1048DE199C32"   
+  "clients": "5790",
+  "pulls": "141065",
+  "pulling": "3",
+  "connections": "16",
+  "idle": "0",
+  "target_connections": "64",
+  "total_blocks": "536820",
+  "lazy_mode": "true",
+  "lazy_blocks": "423388",
+  "lazy_state_unknown": "2",
+  "lazy_balances": "0",
+  "lazy_pulls": "0",
+  "lazy_stopped": "644",
+  "lazy_keys": "449",
+  "lazy_key_1": "A86EB2B479AAF3CD531C8356A1FBE3CB500DFBF5BF292E5E6B8D1048DE199C32"
 }
 ```
 
@@ -940,18 +960,18 @@ Returns a consecutive list of block hashes in the account chain starting at **bl
 
 **Request:**
 ```json
-{  
+{
   "action": "chain",
-  "block": "000D1BAEC8EC208142C99059B393051BAC8380F9B5A2E6B2489A277D81789F3F",  
-  "count": "1"    
+  "block": "000D1BAEC8EC208142C99059B393051BAC8380F9B5A2E6B2489A277D81789F3F",
+  "count": "1"
 }
 ```  
 **Response:**
 ```json
-{    
-  "blocks" : [  
-  "000D1BAEC8EC208142C99059B393051BAC8380F9B5A2E6B2489A277D81789F3F"  
-  ]  
+{
+  "blocks": [
+    "000D1BAEC8EC208142C99059B393051BAC8380F9B5A2E6B2489A277D81789F3F"
+  ]
 }
 ```
 **Optional "offset"**
@@ -979,16 +999,16 @@ Returns list of active elections roots (excluding stopped & aborted elections). 
 
 **Request:**
 ```json
-{  
-  "action": "confirmation_active"      
+{
+  "action": "confirmation_active"
 }
 ```  
 **Response:**
 ```json
-{    
-   "confirmations": [
-       "8031B600827C5CC05FDC911C28BBAC12A0E096CCB30FA8324F56C123676281B28031B600827C5CC05FDC911C28BBAC12A0E096CCB30FA8324F56C123676281B2"   
-   ]
+{
+ "confirmations": [
+   "8031B600827C5CC05FDC911C28BBAC12A0E096CCB30FA8324F56C123676281B28031B600827C5CC05FDC911C28BBAC12A0E096CCB30FA8324F56C123676281B2"
+ ]
 }
 ```   
    
@@ -1007,13 +1027,13 @@ Returns the hash of the block which is having the confirmation height set for, e
 
 **Request:**
 ```json
-{  
-  "action": "confirmation_height_currently_processing"      
+{
+  "action": "confirmation_height_currently_processing"
 }
 ```  
 **Response:**
 ```json
-{    
+{
   "hash": "000D1BAEC8EC208142C99059B393051BAC8380F9B5A2E6B2489A277D81789F3F"
 }
 ```
@@ -1029,43 +1049,43 @@ With version 19.0+ `confirmation_history_size` can be managed in [config.json](/
 
 **Request:**
 ```json
-{  
-  "action": "confirmation_history"      
+{
+  "action": "confirmation_history"
 }
 ```  
 **Response:**
 ```json
-{    
-   "confirmation_stats": {    
-        "count": "2",  
-        "average": "5000"  
+{
+  "confirmation_stats": {
+    "count": "2",
+    "average": "5000"
+  },
+  "confirmations": [
+    {
+      "hash": "EA70B32C55C193345D625F766EEA2FCA52D3F2CCE0B3A30838CC543026BB0FEA",
+      "duration": "4000",
+      "time": "1544819986",
+      "tally": "80394786589602980996311817874549318248"
     },
-   "confirmations": [
-        {
-            "hash": "EA70B32C55C193345D625F766EEA2FCA52D3F2CCE0B3A30838CC543026BB0FEA",
-            "duration": "4000",  
-            "time": "1544819986",   
-            "tally": "80394786589602980996311817874549318248"
-        },
-        {
-            "hash": "F2F8DA6D2CA0A4D78EB043A7A29E12BDE5B4CE7DE1B99A93A5210428EE5B8667",
-            "duration": "6000",  
-            "time": "1544819988",   
-            "tally": "68921714529890443063672782079965877749"
-        }   
-   ]
+    {
+      "hash": "F2F8DA6D2CA0A4D78EB043A7A29E12BDE5B4CE7DE1B99A93A5210428EE5B8667",
+      "duration": "6000",
+      "time": "1544819988",
+      "tally": "68921714529890443063672782079965877749"
+    }
+  ]
 }
 ```   
 **Optional "hash"**
 
 Valid block hash, filters return for only the provided hash. If there is no confirmation available for that hash anymore, the following return can be expected:  
-```  
-`{  
-    "confirmation_stats": {  
-        "count": "0"  
-    },  
-    "confirmations": ""  
-} `  
+```json
+{
+  "confirmation_stats": {
+    "count": "0"
+  },
+  "confirmations": ""
+}
 ```  
 
 If the block is unknown on the node, the following error will be returned:  
@@ -1075,7 +1095,7 @@ If the block is unknown on the node, the following error will be returned:
 
 ### confirmation_info 
 _version 16.0+_   
-Returns info about active election by **root**. Including announcements count, last winner (initially local ledger block), total tally of voted representatives, concurrent blocks with tally & block contents for each  
+Returns info about active election by **root**. Including announcements count, last winner (initially local ledger block), total tally of voted representatives, concurrent blocks with tally & block contents for each. Using the optional `json_block` is recommended since v19.0.
 
 !!! note
     The roots provided are two parts and differ between the first account block and subsequent blocks:
@@ -1086,23 +1106,34 @@ Returns info about active election by **root**. Including announcements count, l
 
 **Request:**
 ```json
-{  
-  "action": "confirmation_info",    
-  "root": "F8BA8CBE61C679231EB06FA03A0CD7CFBE68746396CBBA169BD9E12725682B44F8BA8CBE61C679231EB06FA03A0CD7CFBE68746396CBBA169BD9E12725682B44"    
+{
+  "action": "confirmation_info",
+  "json_block": "true",
+  "root": "EE125B1B1D85D3C24636B3590E1642D9F21B166C0C6CD99C9C6087A1224A0C44EE125B1B1D85D3C24636B3590E1642D9F21B166C0C6CD99C9C6087A1224A0C44"
 }
 ```  
 **Response:**
 ```json
-{    
-    "announcements": "1",   
-    "last_winner": "36CC459675E9FB2DB960C330BAFECB50132DB0394E83C14C7D1359ACB17F5BD2",   
-    "total_tally": "66508449034656215696897986086066451444",   
-    "blocks": {   
-        "36CC459675E9FB2DB960C330BAFECB50132DB0394E83C14C7D1359ACB17F5BD2": {   
-            "tally": "66508449034656215696897986086066451444",   
-            "contents": "{\n    \"type\": \"state\",\n    \"account\": \"nano_3mi58wc8p7uptp5gmt8k4wb5qbizm6chx9rzqi7cybbyxdh38cktw9o65883\",\n    \"previous\": \"F8BA8CBE61C679231EB06FA03A0CD7CFBE68746396CBBA169BD9E12725682B44\",\n    \"representative\": \"nano_3o7uzba8b9e1wqu5ziwpruteyrs3scyqr761x7ke6w1xctohxfh5du75qgaj\",\n    \"balance\": \"61202000000000000000000000000\",\n    \"link\": \"CA24AAAA4BEA37D611EC72ABD283113AC133E3DBF8A7A557CFCA4CF9B354932C\",\n    \"link_as_account\": \"nano_3kj6oco6qtjqtrayrwodtc3j4gp38hjxqy79nodwzkkez8sob6sezmmct61s\",\n    \"signature\": \"744B338DBCDFC2C4849DA44C468EEF99338F1D2D6BADFF20C0F54CB2DE759B512AFE41010EB212CE67D98E10635C2C08AEA517940862EB7DC58E8DFA43B2B408\",\n    \"work\": \"e6d5a6ec29db25d6\"\n}\n"   
-        }   
-    }   
+{
+  "announcements": "2",
+  "last_winner": "B94C505029F04BC057A0486ADA8BD07981B4A8736AE6581F2E98C6D18498146F",
+  "total_tally": "51145880360832646375807054724596663794",
+  "blocks": {
+    "B94C505029F04BC057A0486ADA8BD07981B4A8736AE6581F2E98C6D18498146F": {
+      "tally": "51145880360832646375807054724596663794",
+      "contents": {
+        "type": "state",
+        "account": "nano_3fihmbtuod33s4nrbqfczhk9zy9ddqimwjshzg4c3857es8c9631i5rg6h9p",
+        "previous": "EE125B1B1D85D3C24636B3590E1642D9F21B166C0C6CD99C9C6087A1224A0C44",
+        "representative": "nano_3o7uzba8b9e1wqu5ziwpruteyrs3scyqr761x7ke6w1xctohxfh5du75qgaj",
+        "balance": "218195000000000000000000000000",
+        "link": "0000000000000000000000000000000000000000000000000000000000000000",
+        "link_as_account": "nano_1111111111111111111111111111111111111111111111111111hifc8npp",
+        "signature": "B1BD285235C612C5A141FA61793D7C6C762D3F104A85102DED5FBD6B4514971C4D044ACD3EC8C06A9495D8E83B6941B54F8DABA825ADF799412ED9E2C86D7A0C",
+        "work": "05bb28cd8acbe71d"
+      }
+    }
+  }
 }   
 ```   
 
@@ -1121,31 +1152,42 @@ Boolean, false by default. Returns list of votes representatives & its weights f
 
 **Request:**
 ```json
-{  
-  "action": "confirmation_info",    
-  "root": "F8BA8CBE61C679231EB06FA03A0CD7CFBE68746396CBBA169BD9E12725682B44",   
-  "representatives": "true"   
+{
+  "action": "confirmation_info",
+  "json_block": "true",
+  "root": "F8BA8CBE61C679231EB06FA03A0CD7CFBE68746396CBBA169BD9E12725682B44",
+  "representatives": "true"
 }
 ```  
 **Response:**
 ```json
-{    
-    "announcements": "1",   
-    "last_winner": "36CC459675E9FB2DB960C330BAFECB50132DB0394E83C14C7D1359ACB17F5BD2",   
-    "total_tally": "66508449034656215696897986086066451444",   
-    "blocks": {   
-        "36CC459675E9FB2DB960C330BAFECB50132DB0394E83C14C7D1359ACB17F5BD2": {   
-            "tally": "66508449034656215696897986086066451444",   
-            "contents": "{\n    \"type\": \"state\",\n    \"account\": \"nano_3mi58wc8p7uptp5gmt8k4wb5qbizm6chx9rzqi7cybbyxdh38cktw9o65883\",\n    \"previous\": \"F8BA8CBE61C679231EB06FA03A0CD7CFBE68746396CBBA169BD9E12725682B44\",\n    \"representative\": \"nano_3o7uzba8b9e1wqu5ziwpruteyrs3scyqr761x7ke6w1xctohxfh5du75qgaj\",\n    \"balance\": \"61202000000000000000000000000\",\n    \"link\": \"CA24AAAA4BEA37D611EC72ABD283113AC133E3DBF8A7A557CFCA4CF9B354932C\",\n    \"link_as_account\": \"nano_3kj6oco6qtjqtrayrwodtc3j4gp38hjxqy79nodwzkkez8sob6sezmmct61s\",\n    \"signature\": \"744B338DBCDFC2C4849DA44C468EEF99338F1D2D6BADFF20C0F54CB2DE759B512AFE41010EB212CE67D98E10635C2C08AEA517940862EB7DC58E8DFA43B2B408\",\n    \"work\": \"e6d5a6ec29db25d6\"\n}\n",   
-            "representatives": {   
-                "nano_3pczxuorp48td8645bs3m6c3xotxd3idskrenmi65rbrga5zmkemzhwkaznh": "15542840930304007355829653636255997615",   
-                "nano_1stofnrxuz3cai7ze75o174bpm7scwj9jn3nxsn8ntzg784jf1gzn1jjdkou": "10262330414015196177405695154517720446",   
-                ...    
-                "nano_151jp8kuecdqq3pudrucx4hk5a6nri1fr7r6sbie8zc1ygid1cc4387q9g45": "0"   
-            }   
-        }   
-    }   
-}   
+{
+  "announcements": "5",
+  "last_winner": "B94C505029F04BC057A0486ADA8BD07981B4A8736AE6581F2E98C6D18498146F",
+  "total_tally": "51145880360792646375807054724596663794",
+  "blocks": {
+    "B94C505029F04BC057A0486ADA8BD07981B4A8736AE6581F2E98C6D18498146F": {
+      "tally": "51145880360792646375807054724596663794",
+      "contents": {
+        "type": "state",
+        "account": "nano_3fihmbtuod33s4nrbqfczhk9zy9ddqimwjshzg4c3857es8c9631i5rg6h9p",
+        "previous": "EE125B1B1D85D3C24636B3590E1642D9F21B166C0C6CD99C9C6087A1224A0C44",
+        "representative": "nano_3o7uzba8b9e1wqu5ziwpruteyrs3scyqr761x7ke6w1xctohxfh5du75qgaj",
+        "balance": "218195000000000000000000000000",
+        "link": "0000000000000000000000000000000000000000000000000000000000000000",
+        "link_as_account": "nano_1111111111111111111111111111111111111111111111111111hifc8npp",
+        "signature": "B1BD285235C612C5A141FA61793D7C6C762D3F104A85102DED5FBD6B4514971C4D044ACD3EC8C06A9495D8E83B6941B54F8DABA825ADF799412ED9E2C86D7A0C",
+        "work": "05bb28cd8acbe71d"
+      },
+      "representatives": {
+        "nano_3pczxuorp48td8645bs3m6c3xotxd3idskrenmi65rbrga5zmkemzhwkaznh": "12617828599372664613607727105312358589",
+        "nano_1stofnrxuz3cai7ze75o174bpm7scwj9jn3nxsn8ntzg784jf1gzn1jjdkou": "5953738757270291536911559258663615240",
+        ...
+        "nano_3i4n5n6c6xssapbdtkdoutm88c5zjmatc5tc77xyzdkpef8akid9errcpjnx": "0"
+      }
+    }
+  }
+}
 ```   
 
 ---
@@ -1163,12 +1205,12 @@ Returns information about node elections settings & observed network state: delt
 **Response:**
 ```json
 {
-    "quorum_delta": "41469707173777717318245825935516662250",   
-    "online_weight_quorum_percent": "50",   
-    "online_weight_minimum": "60000000000000000000000000000000000000",   
-    "online_stake_total": "82939414347555434636491651871033324568",   
-    "peers_stake_total": "69026910610720098597176027400951402360",
-    "peers_stake_required": "60000000000000000000000000000000000000"
+  "quorum_delta": "41469707173777717318245825935516662250",
+  "online_weight_quorum_percent": "50",
+  "online_weight_minimum": "60000000000000000000000000000000000000",
+  "online_stake_total": "82939414347555434636491651871033324568",
+  "peers_stake_total": "69026910610720098597176027400951402360",
+  "peers_stake_required": "60000000000000000000000000000000000000"
 }   
 ```   
 
@@ -1204,36 +1246,35 @@ Returns a list of open database transactions which are equal or greater than the
 **Response on Windows/Debug:**  
 ```json
 {
-    "txn_tracking": [
+  "txn_tracking": [
+    {
+      "thread": "Blck processing",  // Which thread held the transaction
+      "time_held_open": "2",        // Seconds the transaction has currently been held open for
+      "write": "true",              // If true it is a write lock, otherwise false.
+      "stacktrace": [
         {
-            "thread": "Blck processing",  // Which thread held the transaction
-            "time_held_open": "2",        // Seconds the transaction has currently been held open for
-            "write": "true",              // If true it is a write lock, otherwise false.
-            "stacktrace": [
-                ...
-                {
-                    "name": "nano::mdb_store::tx_begin_write",
-                    "address": "00007FF7142C5F86",
-                    "source_file": "c:\\users\\wesley\\documents\\raiblocks\\nano\\node\\lmdb.cpp",
-                    "source_line": "825"
-                },
-                {
-                    "name": "nano::block_processor::process_batch",
-                    "address": "00007FF714121EEA",
-                    "source_file": "c:\\users\\wesley\\documents\\raiblocks\\nano\\node\\blockprocessor.cpp",
-                    "source_line": "243"
-                },
-                {
-                    "name": "nano::block_processor::process_blocks",
-                    "address": "00007FF71411F8A6",
-                    "source_file": "c:\\users\\wesley\\documents\\raiblocks\\nano\\node\\blockprocessor.cpp",
-                    "source_line": "103"
-                },
-                ...
-            ]
-        }
-        ....
-    ]
+          "name": "nano::mdb_store::tx_begin_write",
+          "address": "00007FF7142C5F86",
+          "source_file": "c:\\users\\wesley\\documents\\raiblocks\\nano\\node\\lmdb.cpp",
+          "source_line": "825"
+        },
+        {
+          "name": "nano::block_processor::process_batch",
+          "address": "00007FF714121EEA",
+          "source_file": "c:\\users\\wesley\\documents\\raiblocks\\nano\\node\\blockprocessor.cpp",
+          "source_line": "243"
+        },
+        {
+          "name": "nano::block_processor::process_blocks",
+          "address": "00007FF71411F8A6",
+          "source_file": "c:\\users\\wesley\\documents\\raiblocks\\nano\\node\\blockprocessor.cpp",
+          "source_line": "103"
+        },
+        ...
+      ]
+    }
+    ... // other threads
+  ]
 }
 ```
 
@@ -1245,18 +1286,18 @@ Returns a list of pairs of delegator names given **account** a representative an
 
 **Request:**
 ```json
-{  
-  "action": "delegators",    
-  "account": "nano_1111111111111111111111111111111111111111111111111117353trpda"   
+{
+  "action": "delegators",
+  "account": "nano_1111111111111111111111111111111111111111111111111117353trpda"
 }
 ```  
 **Response:**
 ```json
-{    
-   "delegators": {   
-        "nano_13bqhi1cdqq8yb9szneoc38qk899d58i5rcrgdk5mkdm86hekpoez3zxw5sd": "500000000000000000000000000000000000",   
-        "nano_17k6ug685154an8gri9whhe5kb5z1mf5w6y39gokc1657sh95fegm8ht1zpn": "961647970820730000000000000000000000"   
-   }
+{
+  "delegators": {
+    "nano_13bqhi1cdqq8yb9szneoc38qk899d58i5rcrgdk5mkdm86hekpoez3zxw5sd": "500000000000000000000000000000000000",
+    "nano_17k6ug685154an8gri9whhe5kb5z1mf5w6y39gokc1657sh95fegm8ht1zpn": "961647970820730000000000000000000000"
+  }
 }
 ```   
 
@@ -1268,15 +1309,15 @@ Get number of delegators for a specific representative **account**
 
 **Request:**
 ```json
-{  
-  "action": "delegators_count",    
-  "account": "nano_1111111111111111111111111111111111111111111111111117353trpda"   
+{
+  "action": "delegators_count",
+  "account": "nano_1111111111111111111111111111111111111111111111111117353trpda"
 }
 ```  
 **Response:**
 ```json
-{    
-   "count": "2"   
+{
+  "count": "2"
 }
 ```   
 
@@ -1287,18 +1328,18 @@ Derive deterministic keypair from **seed** based on **index**
 
 **Request:**
 ```json
-{  
+{
   "action": "deterministic_key",
-  "seed": "0000000000000000000000000000000000000000000000000000000000000000",  
-  "index": "0"    
+  "seed": "0000000000000000000000000000000000000000000000000000000000000000",
+  "index": "0"
 }
 ```  
 **Response:**
 ```json
-{  
-  "private": "9F0E444C69F77A49BD0BE89DB92C38FE713E0963165CCA12FAF5712D7657120F",  
-  "public": "C008B814A7D269A1FA3C6528B19201A24D797912DB9996FF02A1FF356E45552B",  
-  "account": "nano_3i1aq1cchnmbn9x5rsbap8b15akfh7wj7pwskuzi7ahz8oq6cobd99d4r3b7"  
+{
+  "private": "9F0E444C69F77A49BD0BE89DB92C38FE713E0963165CCA12FAF5712D7657120F",
+  "public": "C008B814A7D269A1FA3C6528B19201A24D797912DB9996FF02A1FF356E45552B",
+  "account": "nano_3i1aq1cchnmbn9x5rsbap8b15akfh7wj7pwskuzi7ahz8oq6cobd99d4r3b7"
 }
 ```  
 
@@ -1309,14 +1350,14 @@ Reports the number of accounts in the ledger
 
 **Request:**
 ```json
-{  
-  "action": "frontier_count"  
+{
+  "action": "frontier_count"
 }
 ```  
 **Response:**
 ```json
 {
-  "count": "920471"  
+  "count": "920471"
 }
 ```
 
@@ -1327,18 +1368,18 @@ Returns a list of pairs of account and block hash representing the head block st
 
 **Request:**
 ```json
-{  
+{
   "action": "frontiers",
-  "account": "nano_1111111111111111111111111111111111111111111111111111hifc8npp",  
-  "count": "1"    
+  "account": "nano_1111111111111111111111111111111111111111111111111111hifc8npp",
+  "count": "1"
 }
 ```  
 **Response:**
 ```json
-{    
-  "frontiers" : {  
-  "nano_3e3j5tkog48pnny9dmfzj1r16pg8t1e76dz5tmac6iq689wyjfpi00000000": "000D1BAEC8EC208142C99059B393051BAC8380F9B5A2E6B2489A277D81789F3F"  
-  }  
+{
+  "frontiers" : {
+    "nano_3e3j5tkog48pnny9dmfzj1r16pg8t1e76dz5tmac6iq689wyjfpi00000000": "000D1BAEC8EC208142C99059B393051BAC8380F9B5A2E6B2489A277D81789F3F"
+  }
 }
 ```
 
@@ -1350,15 +1391,15 @@ Tells the node to send a keepalive packet to **address**:**port**
 
 **Request:**
 ```json
-{  
+{
   "action": "keepalive",
   "address": "::ffff:192.169.0.1",
-  "port": "1024"  
+  "port": "1024"
 }
 ```  
 **Response:**
 ```json
-{      
+{
 }
 ```
 
@@ -1369,16 +1410,16 @@ Generates an **adhoc random keypair**
 
 **Request:**
 ```json
-{  
-  "action": "key_create"  
+{
+  "action": "key_create"
 }
 ```  
 **Response:**
 ```json
-{  
-  "private": "781186FB9EF17DB6E3D1056550D9FAE5D5BBADA6A6BC370E4CBB938B1DC71DA3",  
-  "public": "3068BB1CA04525BB0E416C485FE6A67FD52540227D267CC8B6E8DA958A7FA039",  
-  "account": "nano_1e5aqegc1jb7qe964u4adzmcezyo6o146zb8hm6dft8tkp79za3sxwjym5rx"  
+{
+  "private": "781186FB9EF17DB6E3D1056550D9FAE5D5BBADA6A6BC370E4CBB938B1DC71DA3",
+  "public": "3068BB1CA04525BB0E416C485FE6A67FD52540227D267CC8B6E8DA958A7FA039",
+  "account": "nano_1e5aqegc1jb7qe964u4adzmcezyo6o146zb8hm6dft8tkp79za3sxwjym5rx"
 }
 ```  
 
@@ -1389,17 +1430,17 @@ Derive public key and account number from **private key**
 
 **Request:**
 ```json
-{  
-  "action": "key_expand",  
-  "key": "781186FB9EF17DB6E3D1056550D9FAE5D5BBADA6A6BC370E4CBB938B1DC71DA3"  
+{
+  "action": "key_expand",
+  "key": "781186FB9EF17DB6E3D1056550D9FAE5D5BBADA6A6BC370E4CBB938B1DC71DA3"
 }
 ```  
 **Response:**
 ```json
-{  
-  "private": "781186FB9EF17DB6E3D1056550D9FAE5D5BBADA6A6BC370E4CBB938B1DC71DA3",  
-  "public": "3068BB1CA04525BB0E416C485FE6A67FD52540227D267CC8B6E8DA958A7FA039",  
-  "account": "nano_1e5aqegc1jb7qe964u4adzmcezyo6o146zb8hm6dft8tkp79za3sxwjym5rx"  
+{
+  "private": "781186FB9EF17DB6E3D1056550D9FAE5D5BBADA6A6BC370E4CBB938B1DC71DA3",
+  "public": "3068BB1CA04525BB0E416C485FE6A67FD52540227D267CC8B6E8DA958A7FA039",
+  "account": "nano_1e5aqegc1jb7qe964u4adzmcezyo6o146zb8hm6dft8tkp79za3sxwjym5rx"
 }
 ```  
 
@@ -1413,25 +1454,25 @@ Returns frontier, open block, change representative block, balance, last modifie
 
 **Request:**
 ```json
-{  
-  "action": "ledger",  
-  "account": "nano_1111111111111111111111111111111111111111111111111111hifc8npp",   
-  "count": "1"    
+{
+  "action": "ledger",
+  "account": "nano_1111111111111111111111111111111111111111111111111111hifc8npp",
+  "count": "1"
 }
 ```  
 **Response:**
 ```json
-{  
-  "accounts": {   
-    "nano_11119gbh8hb4hj1duf7fdtfyf5s75okzxdgupgpgm1bj78ex3kgy7frt3s9n": {   
-      "frontier": "E71AF3E9DD86BBD8B4620EFA63E065B34D358CFC091ACB4E103B965F95783321",   
-      "open_block": "643B77F1ECEFBDBE1CC909872964C1DBBE23A6149BD3CEF2B50B76044659B60F",   
-      "representative_block": "643B77F1ECEFBDBE1CC909872964C1DBBE23A6149BD3CEF2B50B76044659B60F",   
-      "balance": "0",   
-      "modified_timestamp": "1511476234",   
-      "block_count": "2"   
-    }   
-  }   
+{
+  "accounts": {
+    "nano_11119gbh8hb4hj1duf7fdtfyf5s75okzxdgupgpgm1bj78ex3kgy7frt3s9n": {
+      "frontier": "E71AF3E9DD86BBD8B4620EFA63E065B34D358CFC091ACB4E103B965F95783321",
+      "open_block": "643B77F1ECEFBDBE1CC909872964C1DBBE23A6149BD3CEF2B50B76044659B60F",
+      "representative_block": "643B77F1ECEFBDBE1CC909872964C1DBBE23A6149BD3CEF2B50B76044659B60F",
+      "balance": "0",
+      "modified_timestamp": "1511476234",
+      "block_count": "2"
+    }
+  }
 }
 ```  
 **Optional "representative", "weight", "pending"**  
@@ -1439,29 +1480,29 @@ Booleans, false by default. Additionally returns representative, voting weight, 
 
 **Request:**
 ```json
-{  
-  "action": "ledger",  
-  "account": "nano_1111111111111111111111111111111111111111111111111111hifc8npp",   
-  "count": "1",   
-  "representative": "true",  
-  "weight": "true",  
-  "pending": "true"  
+{
+  "action": "ledger",
+  "account": "nano_1111111111111111111111111111111111111111111111111111hifc8npp",
+  "count": "1",
+  "representative": "true",
+  "weight": "true",
+  "pending": "true"
 }
 ```  
 **Response:**
 ```json
-{  
-  "accounts": {   
-    "nano_11119gbh8hb4hj1duf7fdtfyf5s75okzxdgupgpgm1bj78ex3kgy7frt3s9n": {   
-      "frontier": "E71AF3E9DD86BBD8B4620EFA63E065B34D358CFC091ACB4E103B965F95783321",  
-      "open_block": "643B77F1ECEFBDBE1CC909872964C1DBBE23A6149BD3CEF2B50B76044659B60F",   
-      "representative_block": "643B77F1ECEFBDBE1CC909872964C1DBBE23A6149BD3CEF2B50B76044659B60F",   
-      "balance": "0",   
-      "modified_timestamp": "1511476234",   
-      "block_count": "2",   
-      "representative": "nano_1anrzcuwe64rwxzcco8dkhpyxpi8kd7zsjc1oeimpc3ppca4mrjtwnqposrs",   
-      "weight": "0",   
-      "pending": "0"   
+{
+  "accounts": {
+    "nano_11119gbh8hb4hj1duf7fdtfyf5s75okzxdgupgpgm1bj78ex3kgy7frt3s9n": {
+      "frontier": "E71AF3E9DD86BBD8B4620EFA63E065B34D358CFC091ACB4E103B965F95783321",
+      "open_block": "643B77F1ECEFBDBE1CC909872964C1DBBE23A6149BD3CEF2B50B76044659B60F",
+      "representative_block": "643B77F1ECEFBDBE1CC909872964C1DBBE23A6149BD3CEF2B50B76044659B60F",
+      "balance": "0",
+      "modified_timestamp": "1511476234",
+      "block_count": "2",
+      "representative": "nano_1anrzcuwe64rwxzcco8dkhpyxpi8kd7zsjc1oeimpc3ppca4mrjtwnqposrs",
+      "weight": "0",
+      "pending": "0"
     }   
   }   
 }
@@ -1490,17 +1531,17 @@ _version 20.0 will generate the node_id with `node_` prefix, earlier versions wi
 
 **Request:**
 ```json
-{  
-    "action": "node_id"  
+{
+  "action": "node_id"
 }
 ```  
 **Response:**
 ```json
-{  
-    "private": "2AD75C9DC20EA497E41722290C4DC966ECC4D6C75CAA4E447961F918FD73D8C7",  
-    "public": "78B11E1777B8E7DF9090004376C3EDE008E84680A497C0805F68CA5928626E1C",  
-    "as_account": "nano_1y7j5rdqhg99uyab1145gu3yur1ax35a3b6qr417yt8cd6n86uiw3d4whty3",  
-    "node_id": "node_1y7j5rdqhg99uyab1145gu3yur1ax35a3b6qr417yt8cd6n86uiw3d4whty3"  
+{
+  "private": "2AD75C9DC20EA497E41722290C4DC966ECC4D6C75CAA4E447961F918FD73D8C7",
+  "public": "78B11E1777B8E7DF9090004376C3EDE008E84680A497C0805F68CA5928626E1C",
+  "as_account": "nano_1y7j5rdqhg99uyab1145gu3yur1ax35a3b6qr417yt8cd6n86uiw3d4whty3",
+  "node_id": "node_1y7j5rdqhg99uyab1145gu3yur1ax35a3b6qr417yt8cd6n86uiw3d4whty3"
 }
 ```  
 
@@ -1515,14 +1556,14 @@ Removing node ID (restart required to take effect)
 
 **Request:**
 ```json
-{  
-    "action": "node_id_delete"  
+{
+  "action": "node_id_delete"
 }
 ```  
 **Response:**
 ```json
-{  
-    "deleted": "1"  
+{
+  "deleted": "1"
 }
 ```  
 
@@ -1533,26 +1574,26 @@ Returns a list of pairs of online peer IPv6:port and its node protocol network v
 
 **Request:**
 ```json
-{  
-  "action": "peers" 
+{
+  "action": "peers"
 }
 ```  
  
 **Response version 8.0+:**
 ```json
 {
-    "peers": {  
-        "[::ffff:172.17.0.1]:32841": "16"  
-    }  
+  "peers": {
+    "[::ffff:172.17.0.1]:32841": "16"
+  }
 }
 ```   
 
 **Response before version 8.0:**
 ```json
 {
-    "peers": [  
-        "[::ffff:172.17.0.1]:32841"  
-    ]  
+  "peers": [
+      "[::ffff:172.17.0.1]:32841"
+  ]
 }
 ```   
 **Optional "peer_details"**
@@ -1565,13 +1606,13 @@ _version 20.0 will generate the node_id with `node_` prefix, earlier versions wi
 **Response:**
 ```json
 {
-    "peers": {  
-        "[::ffff:172.17.0.1]:32841": {  
-           "protocol_version": "16",  
-           "node_id": "node_1y7j5rdqhg99uyab1145gu3yur1ax35a3b6qr417yt8cd6n86uiw3d4whty3",
-           "type": "udp"
-        }  
-    }  
+  "peers": {
+    "[::ffff:172.17.0.1]:32841": {
+      "protocol_version": "16",
+      "node_id": "node_1y7j5rdqhg99uyab1145gu3yur1ax35a3b6qr417yt8cd6n86uiw3d4whty3",
+      "type": "udp"
+    }
+  }
 }
 ```
 
@@ -1582,16 +1623,16 @@ Returns a list of block hashes which have not yet been received by this account.
 
 **Request:**
 ```json
-{  
+{
   "action": "pending",
-  "account": "nano_1111111111111111111111111111111111111111111111111117353trpda",  
-  "count": "1"    
+  "account": "nano_1111111111111111111111111111111111111111111111111117353trpda",
+  "count": "1"
 }
 ```  
 **Response:**
 ```json
-{    
-  "blocks" : [ "000D1BAEC8EC208142C99059B393051BAC8380F9B5A2E6B2489A277D81789F3F" ]  
+{
+  "blocks": [ "000D1BAEC8EC208142C99059B393051BAC8380F9B5A2E6B2489A277D81789F3F" ]
 }
 ```   
 **Optional "count"**  
@@ -1603,19 +1644,19 @@ Number (128 bit, decimal). Returns a list of pending block hashes with amount mo
 
 **Request:**
 ```json
-{  
-  "action": "pending",  
-  "account": "nano_1111111111111111111111111111111111111111111111111117353trpda",  
-  "count": "1",  
-  "threshold": "1000000000000000000000000"   
+{
+  "action": "pending",
+  "account": "nano_1111111111111111111111111111111111111111111111111117353trpda",
+  "count": "1",
+  "threshold": "1000000000000000000000000"
 }
 ```  
 **Response:**
 ```json
-{  
-  "blocks" : {    
-        "000D1BAEC8EC208142C99059B393051BAC8380F9B5A2E6B2489A277D81789F3F": "6000000000000000000000000000000"    
-    }  
+{
+  "blocks" : {
+    "000D1BAEC8EC208142C99059B393051BAC8380F9B5A2E6B2489A277D81789F3F": "6000000000000000000000000000000"
+  }
 }
 ```  
 **Optional "source"**  
@@ -1624,22 +1665,22 @@ Boolean, false by default. Returns a list of pending block hashes with amount an
 
 **Request:**
 ```json
-{  
-  "action": "pending",  
-  "account": "nano_1111111111111111111111111111111111111111111111111117353trpda",  
-  "count": "1",  
-  "source": "true"   
+{
+  "action": "pending",
+  "account": "nano_1111111111111111111111111111111111111111111111111117353trpda",
+  "count": "1",
+  "source": "true"
 }
 ```  
 **Response:**
 ```json
-{  
-  "blocks" : {    
-        "000D1BAEC8EC208142C99059B393051BAC8380F9B5A2E6B2489A277D81789F3F": {   
-             "amount": "6000000000000000000000000000000",       
-             "source": "nano_3dcfozsmekr1tr9skf1oa5wbgmxt81qepfdnt7zicq5x3hk65fg4fqj58mbr"  
-        }   
-    }  
+{
+  "blocks" : {
+    "000D1BAEC8EC208142C99059B393051BAC8380F9B5A2E6B2489A277D81789F3F": {
+      "amount": "6000000000000000000000000000000",
+      "source": "nano_3dcfozsmekr1tr9skf1oa5wbgmxt81qepfdnt7zicq5x3hk65fg4fqj58mbr"
+    }
+  }
 }
 ```  
 **Optional "include_active"**
@@ -1649,11 +1690,11 @@ Boolean, false by default. Include active blocks without finished confirmations
 
 **Request:**
 ```json
-{  
-  "action": "pending",  
-  "account": "nano_1111111111111111111111111111111111111111111111111117353trpda",  
-  "count": "1",  
-  "include_active": "true"   
+{
+  "action": "pending",
+  "account": "nano_1111111111111111111111111111111111111111111111111117353trpda",
+  "count": "1",
+  "include_active": "true"
 }
 ```  
 **Optional "sorting"**
@@ -1674,14 +1715,14 @@ Check whether block is pending by **hash**
 
 **Request:**
 ```json
-{  
+{
   "action": "pending_exists",
-  "hash": "000D1BAEC8EC208142C99059B393051BAC8380F9B5A2E6B2489A277D81789F3F" 
+  "hash": "000D1BAEC8EC208142C99059B393051BAC8380F9B5A2E6B2489A277D81789F3F"
 }
 ```  
 **Response:**
 ```json
-{  
+{
   "exists" : "1"
 }
 ```
@@ -1693,10 +1734,10 @@ Boolean, false by default. Include active blocks without finished confirmations
 
 **Request:**
 ```json
-{  
-  "action": "pending_exists",  
-  "hash": "000D1BAEC8EC208142C99059B393051BAC8380F9B5A2E6B2489A277D81789F3F", 
-  "include_active": "true"   
+{
+  "action": "pending_exists",
+  "hash": "000D1BAEC8EC208142C99059B393051BAC8380F9B5A2E6B2489A277D81789F3F",
+  "include_active": "true"
 }
 ```  
 
@@ -1712,25 +1753,25 @@ Publish **block** to the network
 
 **Request:**
 ```json
-{  
-  "action": "process",  
-  "block": "{   
-    \"type\": \"state\",   
-    \"account\": \"nano_1qato4k7z3spc8gq1zyd8xeqfbzsoxwo36a45ozbrxcatut7up8ohyardu1z\",   
-    \"previous\": \"6CDDA48608C7843A0AC1122BDD46D9E20E21190986B19EAC23E7F33F2E6A6766\",   
-    \"representative\": \"nano_3pczxuorp48td8645bs3m6c3xotxd3idskrenmi65rbrga5zmkemzhwkaznh\",   
-    \"balance\": \"40200000001000000000000000000000000\",   
-    \"link\": \"87434F8041869A01C8F6F263B87972D7BA443A72E0A97D7A3FD0CCC2358FD6F9\",   
-    \"link_as_account\": \"nano_33t5by1653nt196hfwm5q3wq7oxtaix97r7bhox5zn8eratrzoqsny49ftsd\",   
-    \"signature\": \"A5DB164F6B81648F914E49CAB533900C389FAAD64FBB24F6902F9261312B29F730D07E9BCCD21D918301419B4E05B181637CF8419ED4DCBF8EF2539EB2467F07\",   
-    \"work\": \"000bc55b014e807d\"   
-  }"   
+{
+  "action": "process",
+  "block": "{
+    \"type\": \"state\",
+    \"account\": \"nano_1qato4k7z3spc8gq1zyd8xeqfbzsoxwo36a45ozbrxcatut7up8ohyardu1z\",
+    \"previous\": \"6CDDA48608C7843A0AC1122BDD46D9E20E21190986B19EAC23E7F33F2E6A6766\",
+    \"representative\": \"nano_3pczxuorp48td8645bs3m6c3xotxd3idskrenmi65rbrga5zmkemzhwkaznh\",
+    \"balance\": \"40200000001000000000000000000000000\",
+    \"link\": \"87434F8041869A01C8F6F263B87972D7BA443A72E0A97D7A3FD0CCC2358FD6F9\",
+    \"link_as_account\": \"nano_33t5by1653nt196hfwm5q3wq7oxtaix97r7bhox5zn8eratrzoqsny49ftsd\",
+    \"signature\": \"A5DB164F6B81648F914E49CAB533900C389FAAD64FBB24F6902F9261312B29F730D07E9BCCD21D918301419B4E05B181637CF8419ED4DCBF8EF2539EB2467F07\",
+    \"work\": \"000bc55b014e807d\"
+  }"
 }
 ```  
 **Response:**
 ```json
-{  
-  "hash": "E2FB233EF4554077A7BF1AA85851D5BF0B36965D2B0FB504B2BC778AB89917D3"   
+{
+  "hash": "E2FB233EF4554077A7BF1AA85851D5BF0B36965D2B0FB504B2BC778AB89917D3"
 }
 ```
 **Optional "force"**
@@ -1755,18 +1796,18 @@ Returns a list of pairs of representative and its voting weight
 
 **Request:**
 ```json
-{  
-  "action": "representatives"    
+{
+  "action": "representatives"
 }
 ```  
 **Response:**
 ```json
-{    
-  "representatives" : {  
-    "nano_1111111111111111111111111111111111111111111111111117353trpda": "3822372327060170000000000000000000000",  
-    "nano_1111111111111111111111111111111111111111111111111awsq94gtecn": "30999999999999999999999999000000",  
-    "nano_114nk4rwjctu6n6tr6g6ps61g1w3hdpjxfas4xj1tq6i8jyomc5d858xr1xi": "0"  
-  }  
+{
+  "representatives": {
+    "nano_1111111111111111111111111111111111111111111111111117353trpda": "3822372327060170000000000000000000000",
+    "nano_1111111111111111111111111111111111111111111111111awsq94gtecn": "30999999999999999999999999000000",
+    "nano_114nk4rwjctu6n6tr6g6ps61g1w3hdpjxfas4xj1tq6i8jyomc5d858xr1xi": "0"
+  }
 }
 ```
 **Optional "count"**
@@ -1780,7 +1821,6 @@ _version 9.0+_
 Boolean, false by default. Additional sorting representatives in descending order  
 NOTE: The "count" option is ignored if "sorting" is specified  
 
-
 ---
 
 ### representatives_online  
@@ -1789,30 +1829,30 @@ Returns a list of online representative accounts that have voted recently
 
 **Request:**
 ```json
-{  
-  "action": "representatives_online"    
+{
+  "action": "representatives_online"
 }
 ```  
 **Response:**
 ```json
-{    
-  "representatives" : [  
-    "nano_1111111111111111111111111111111111111111111111111117353trpda",  
-    "nano_1111111111111111111111111111111111111111111111111awsq94gtecn",  
-    "nano_114nk4rwjctu6n6tr6g6ps61g1w3hdpjxfas4xj1tq6i8jyomc5d858xr1xi"  
-  ]  
+{
+  "representatives": [
+    "nano_1111111111111111111111111111111111111111111111111117353trpda",
+    "nano_1111111111111111111111111111111111111111111111111awsq94gtecn",
+    "nano_114nk4rwjctu6n6tr6g6ps61g1w3hdpjxfas4xj1tq6i8jyomc5d858xr1xi"
+  ]
 }
 ```
 _versions 11.2–17.1_   
 Returns a list of pairs of online representative accounts that have voted recently and empty strings  
 **Response:**
 ```json
-{    
-  "representatives" : {  
-    "nano_1111111111111111111111111111111111111111111111111117353trpda": "",  
-    "nano_1111111111111111111111111111111111111111111111111awsq94gtecn": "",  
-    "nano_114nk4rwjctu6n6tr6g6ps61g1w3hdpjxfas4xj1tq6i8jyomc5d858xr1xi": ""  
-  }  
+{
+  "representatives" : {
+    "nano_1111111111111111111111111111111111111111111111111117353trpda": "",
+    "nano_1111111111111111111111111111111111111111111111111awsq94gtecn": "",
+    "nano_114nk4rwjctu6n6tr6g6ps61g1w3hdpjxfas4xj1tq6i8jyomc5d858xr1xi": ""
+  }
 }
 ```
 **Optional "weight"**
@@ -1821,12 +1861,12 @@ _version 17.0+_
 Boolean, false by default. Returns voting weight for each representative.  
 **Response:**
 ```json
-{    
-  "representatives" : {  
+{
+  "representatives": {
     "nano_114nk4rwjctu6n6tr6g6ps61g1w3hdpjxfas4xj1tq6i8jyomc5d858xr1xi": {
-            "weight": "150462654614686936429917024683496890"
-        }  
-  }  
+      "weight": "150462654614686936429917024683496890"
+    }
+  }
 }
 ```
 
@@ -1837,18 +1877,18 @@ Rebroadcast blocks starting at **hash** to the network
 
 **Request:**
 ```json
-{  
-  "action": "republish",    
-  "hash": "991CF190094C00F0B68E2E5F75F6BEE95A2E0BD93CEAA4A6734DB9F19B728948"    
+{
+  "action": "republish",
+  "hash": "991CF190094C00F0B68E2E5F75F6BEE95A2E0BD93CEAA4A6734DB9F19B728948"
 }
 ```  
 **Response:**
 ```json
-{    
-  "blocks": [   
-     "991CF190094C00F0B68E2E5F75F6BEE95A2E0BD93CEAA4A6734DB9F19B728948",   
-     "A170D51B94E00371ACE76E35AC81DC9405D5D04D4CEBC399AEACE07AE05DD293"
-  ]       
+{
+  "blocks": [
+    "991CF190094C00F0B68E2E5F75F6BEE95A2E0BD93CEAA4A6734DB9F19B728948",
+    "A170D51B94E00371ACE76E35AC81DC9405D5D04D4CEBC399AEACE07AE05DD293"
+  ]
 }
 ```   
 
@@ -1859,21 +1899,21 @@ Boolean, false by default. Additionally rebroadcast source chain blocks for rece
 
 **Request:**
 ```json
-{  
-  "action": "republish",    
-  "hash": "90D0C16AC92DD35814E84BFBCC739A039615D0A42A76EF44ADAEF1D99E9F8A35",    
-  "count": "1",    
-  "sources": "2"   
+{
+  "action": "republish",
+  "hash": "90D0C16AC92DD35814E84BFBCC739A039615D0A42A76EF44ADAEF1D99E9F8A35",
+  "count": "1",
+  "sources": "2"
 }
 ```  
 **Response:**
 ```json
-{    
-  "blocks": [   
-      "991CF190094C00F0B68E2E5F75F6BEE95A2E0BD93CEAA4A6734DB9F19B728948",   
-      "A170D51B94E00371ACE76E35AC81DC9405D5D04D4CEBC399AEACE07AE05DD293",   
-      "90D0C16AC92DD35814E84BFBCC739A039615D0A42A76EF44ADAEF1D99E9F8A35"   
-  ]       
+{
+  "blocks": [
+    "991CF190094C00F0B68E2E5F75F6BEE95A2E0BD93CEAA4A6734DB9F19B728948",
+    "A170D51B94E00371ACE76E35AC81DC9405D5D04D4CEBC399AEACE07AE05DD293",
+    "90D0C16AC92DD35814E84BFBCC739A039615D0A42A76EF44ADAEF1D99E9F8A35"
+  ]
 }
 ```   
 
@@ -1884,21 +1924,21 @@ Boolean, false by default. Additionally rebroadcast destination chain blocks fro
 
 **Request:**
 ```json
-{  
-  "action": "republish",    
-  "hash": "A170D51B94E00371ACE76E35AC81DC9405D5D04D4CEBC399AEACE07AE05DD293",    
-  "count": "1",    
-  "destinations": "2"   
+{
+  "action": "republish",
+  "hash": "A170D51B94E00371ACE76E35AC81DC9405D5D04D4CEBC399AEACE07AE05DD293",
+  "count": "1",
+  "destinations": "2"
 }
 ```  
 **Response:**
 ```json
-{    
-  "blocks": [   
-      "A170D51B94E00371ACE76E35AC81DC9405D5D04D4CEBC399AEACE07AE05DD293",   
-      "90D0C16AC92DD35814E84BFBCC739A039615D0A42A76EF44ADAEF1D99E9F8A35",   
-      "18563C814A54535B7C12BF76A0E23291BA3769536634AB90AD0305776A533E8E"   
-  ]       
+{
+  "blocks": [
+    "A170D51B94E00371ACE76E35AC81DC9405D5D04D4CEBC399AEACE07AE05DD293",
+    "90D0C16AC92DD35814E84BFBCC739A039615D0A42A76EF44ADAEF1D99E9F8A35",
+    "18563C814A54535B7C12BF76A0E23291BA3769536634AB90AD0305776A533E8E"
+  ]
 }
 ```   
 
@@ -1906,61 +1946,63 @@ Boolean, false by default. Additionally rebroadcast destination chain blocks fro
 
 ### sign
 _version 18.0+_  
-Signing provided **block** with private **key** or key of **account** from **wallet**
+Signing provided **block** with private **key** or key of **account** from **wallet**. Using the optional `json_block` is recommended since v19.0.  
 
 **Request with private key:**
 ```json
 {
-  "action": "sign",  
-  "key": "1D3759BB2CA187A66875D3B8497624159A576FD315E07F702B99B92BC59FC14A",  
-  "block": "{   
-    \"type\": \"state\",   
-    \"account\": \"nano_1qato4k7z3spc8gq1zyd8xeqfbzsoxwo36a45ozbrxcatut7up8ohyardu1z\",   
-    \"previous\": \"6CDDA48608C7843A0AC1122BDD46D9E20E21190986B19EAC23E7F33F2E6A6766\",   
-    \"representative\": \"nano_3pczxuorp48td8645bs3m6c3xotxd3idskrenmi65rbrga5zmkemzhwkaznh\",   
-    \"balance\": \"40200000001000000000000000000000000\",   
-    \"link\": \"87434F8041869A01C8F6F263B87972D7BA443A72E0A97D7A3FD0CCC2358FD6F9\",   
-    \"link_as_account\": \"nano_33t5by1653nt196hfwm5q3wq7oxtaix97r7bhox5zn8eratrzoqsny49ftsd\",   
-    \"signature\": \"A5DB164F6B81648F914E49CAB533900C389FAAD64FBB24F6902F9261312B29F730D07E9BCCD21D918301419B4E05B181637CF8419ED4DCBF8EF2539EB2467F07\",   
-    \"work\": \"000bc55b014e807d\"   
-  }"   
+  "action": "sign",
+  "json_block": "true",
+  "key": "1D3759BB2CA187A66875D3B8497624159A576FD315E07F702B99B92BC59FC14A",
+  "block": {
+    "type": "state",
+    "account": "nano_1qato4k7z3spc8gq1zyd8xeqfbzsoxwo36a45ozbrxcatut7up8ohyardu1z",
+    "previous": "6CDDA48608C7843A0AC1122BDD46D9E20E21190986B19EAC23E7F33F2E6A6766",
+    "representative": "nano_3pczxuorp48td8645bs3m6c3xotxd3idskrenmi65rbrga5zmkemzhwkaznh",
+    "balance": "40200000001000000000000000000000000",
+    "link": "87434F8041869A01C8F6F263B87972D7BA443A72E0A97D7A3FD0CCC2358FD6F9",
+    "link_as_account": "nano_33t5by1653nt196hfwm5q3wq7oxtaix97r7bhox5zn8eratrzoqsny49ftsd",
+    "signature": "A5DB164F6B81648F914E49CAB533900C389FAAD64FBB24F6902F9261312B29F730D07E9BCCD21D918301419B4E05B181637CF8419ED4DCBF8EF2539EB2467F07",
+    "work": "000bc55b014e807d"
+  }
 }
 ```
 
 **Request with account from wallet:**
 ```json
 {
-  "action": "sign",  
-  "wallet": "000D1BAEC8EC208142C99059B393051BAC8380F9B5A2E6B2489A277D81789F3F",  
-  "account": "nano_18ky5chy5ws89oi46ki4zjy6x5ezpmj98zg6icwke9bmuy99nosieyqf8c1h",  
-  "block": "{   
-    \"type\": \"state\",   
-    \"account\": \"nano_1qato4k7z3spc8gq1zyd8xeqfbzsoxwo36a45ozbrxcatut7up8ohyardu1z\",   
-    \"previous\": \"6CDDA48608C7843A0AC1122BDD46D9E20E21190986B19EAC23E7F33F2E6A6766\",   
-    \"representative\": \"nano_3pczxuorp48td8645bs3m6c3xotxd3idskrenmi65rbrga5zmkemzhwkaznh\",   
-    \"balance\": \"40200000001000000000000000000000000\",   
-    \"link\": \"87434F8041869A01C8F6F263B87972D7BA443A72E0A97D7A3FD0CCC2358FD6F9\",   
-    \"link_as_account\": \"nano_33t5by1653nt196hfwm5q3wq7oxtaix97r7bhox5zn8eratrzoqsny49ftsd\",   
-    \"signature\": \"A5DB164F6B81648F914E49CAB533900C389FAAD64FBB24F6902F9261312B29F730D07E9BCCD21D918301419B4E05B181637CF8419ED4DCBF8EF2539EB2467F07\",   
-    \"work\": \"000bc55b014e807d\"   
-  }"   
+  "action": "sign",
+  "json_block": "true",
+  "wallet": "000D1BAEC8EC208142C99059B393051BAC8380F9B5A2E6B2489A277D81789F3F",
+  "account": "nano_18ky5chy5ws89oi46ki4zjy6x5ezpmj98zg6icwke9bmuy99nosieyqf8c1h",
+  "block": {
+    "type": "state",
+    "account": "nano_1qato4k7z3spc8gq1zyd8xeqfbzsoxwo36a45ozbrxcatut7up8ohyardu1z",
+    "previous": "6CDDA48608C7843A0AC1122BDD46D9E20E21190986B19EAC23E7F33F2E6A6766",
+    "representative": "nano_3pczxuorp48td8645bs3m6c3xotxd3idskrenmi65rbrga5zmkemzhwkaznh",
+    "balance": "40200000001000000000000000000000000",
+    "link": "87434F8041869A01C8F6F263B87972D7BA443A72E0A97D7A3FD0CCC2358FD6F9",
+    "link_as_account": "nano_33t5by1653nt196hfwm5q3wq7oxtaix97r7bhox5zn8eratrzoqsny49ftsd",
+    "signature": "A5DB164F6B81648F914E49CAB533900C389FAAD64FBB24F6902F9261312B29F730D07E9BCCD21D918301419B4E05B181637CF8419ED4DCBF8EF2539EB2467F07",
+    "work": "000bc55b014e807d"
+  }
 }
 ```
 **Response:**
 ```json
-{  
-  "signature": "2A71F3877033F5966735F260E906BFCB7FA82CDD543BCD1224F180F85A96FC26CB3F0E4180E662332A0DFE4EE6A0F798A71C401011E635604E532383EC08C70D",  
-  "block": "{   
-    \"type\": \"state\",   
-    \"account\": \"nano_1qato4k7z3spc8gq1zyd8xeqfbzsoxwo36a45ozbrxcatut7up8ohyardu1z\",   
-    \"previous\": \"6CDDA48608C7843A0AC1122BDD46D9E20E21190986B19EAC23E7F33F2E6A6766\",   
-    \"representative\": \"nano_3pczxuorp48td8645bs3m6c3xotxd3idskrenmi65rbrga5zmkemzhwkaznh\",   
-    \"balance\": \"40200000001000000000000000000000000\",   
-    \"link\": \"87434F8041869A01C8F6F263B87972D7BA443A72E0A97D7A3FD0CCC2358FD6F9\",   
-    \"link_as_account\": \"nano_33t5by1653nt196hfwm5q3wq7oxtaix97r7bhox5zn8eratrzoqsny49ftsd\",   
-    \"signature\": \"2A71F3877033F5966735F260E906BFCB7FA82CDD543BCD1224F180F85A96FC26CB3F0E4180E662332A0DFE4EE6A0F798A71C401011E635604E532383EC08C70D\",   
-    \"work\": \"000bc55b014e807d\"   
-  }"   
+{
+  "signature": "2A71F3877033F5966735F260E906BFCB7FA82CDD543BCD1224F180F85A96FC26CB3F0E4180E662332A0DFE4EE6A0F798A71C401011E635604E532383EC08C70D",
+  "block": {
+    "type": "state",
+    "account": "nano_1qato4k7z3spc8gq1zyd8xeqfbzsoxwo36a45ozbrxcatut7up8ohyardu1z",
+    "previous": "6CDDA48608C7843A0AC1122BDD46D9E20E21190986B19EAC23E7F33F2E6A6766",
+    "representative": "nano_3pczxuorp48td8645bs3m6c3xotxd3idskrenmi65rbrga5zmkemzhwkaznh",
+    "balance": "40200000001000000000000000000000000",
+    "link": "87434F8041869A01C8F6F263B87972D7BA443A72E0A97D7A3FD0CCC2358FD6F9",
+    "link_as_account": "nano_33t5by1653nt196hfwm5q3wq7oxtaix97r7bhox5zn8eratrzoqsny49ftsd",
+    "signature": "2A71F3877033F5966735F260E906BFCB7FA82CDD543BCD1224F180F85A96FC26CB3F0E4180E662332A0DFE4EE6A0F798A71C401011E635604E532383EC08C70D",
+    "work": "000bc55b014e807d"
+  }
 }
 ```
 
@@ -1976,14 +2018,14 @@ _Requires config.json modification. Set "enable_sign_hash" to "true"_
 **Request:**
 ```json
 {
-  "action": "sign",  
-  "hash": "E2FB233EF4554077A7BF1AA85851D5BF0B36965D2B0FB504B2BC778AB89917D3"  
+  "action": "sign",
+  "hash": "E2FB233EF4554077A7BF1AA85851D5BF0B36965D2B0FB504B2BC778AB89917D3"
 }
 ```  
 **Response:**
 ```json
-{  
-  "signature": "2A71F3877033F5966735F260E906BFCB7FA82CDD543BCD1224F180F85A96FC26CB3F0E4180E662332A0DFE4EE6A0F798A71C401011E635604E532383EC08C70D"   
+{
+  "signature": "2A71F3877033F5966735F260E906BFCB7FA82CDD543BCD1224F180F85A96FC26CB3F0E4180E662332A0DFE4EE6A0F798A71C401011E635604E532383EC08C70D"
 }
 ```  
 
@@ -1996,33 +2038,33 @@ For configuration and other details, please see [Statistics from RPC](/running-a
 **Request counters:**
 ```json
 {
-    "action": "stats",
-    "type": "counters"
+  "action": "stats",
+  "type": "counters"
 }
 ```
 
 **Counters response:**
 ```json
 {
-    "type": "counters",
-    "created": "2018.03.29 01:46:36",
-    "entries": [
-        {
-            "time": "01:46:36",
-            "type": "traffic",
-            "detail": "all",
-            "dir": "in",
-            "value": "3122792"
-        },
-        {
-            "time": "01:46:36",
-            "type": "traffic",
-            "detail": "all",
-            "dir": "out",
-            "value": "203184"
-        } 
-        ...
-    ]
+  "type": "counters",
+  "created": "2018.03.29 01:46:36",
+  "entries": [
+    {
+      "time": "01:46:36",
+      "type": "traffic",
+      "detail": "all",
+      "dir": "in",
+      "value": "3122792"
+    },
+    {
+      "time": "01:46:36",
+      "type": "traffic",
+      "detail": "all",
+      "dir": "out",
+      "value": "203184"
+    }
+    ...
+  ]
 }
 ```
 
@@ -2031,33 +2073,33 @@ _version 18.0+ also returns "stat_duration_seconds": the number of seconds since
 **Request samples:**
 ```json
 {
-    "action": "stats",
-    "type": "samples"
+  "action": "stats",
+  "type": "samples"
 }
 ```
 
 **Samples response:**
 ```json
 {
-    "type": "samples",
-    "created": "2018.03.29 01:47:08",
-    "entries": [
-        {
-            "time": "01:47:04",
-            "type": "traffic",
-            "detail": "all",
-            "dir": "in",
-            "value": "59480"
-        },
-        {
-            "time": "01:47:05",
-            "type": "traffic",
-            "detail": "all",
-            "dir": "in",
-            "value": "44496"
-        }
-        ...
-     ]
+  "type": "samples",
+  "created": "2018.03.29 01:47:08",
+  "entries": [
+    {
+      "time": "01:47:04",
+      "type": "traffic",
+      "detail": "all",
+      "dir": "in",
+      "value": "59480"
+    },
+    {
+      "time": "01:47:05",
+      "type": "traffic",
+      "detail": "all",
+      "dir": "in",
+      "value": "44496"
+    }
+    ...
+   ]
 }
 ```
 _version 18.0+_  
@@ -2066,33 +2108,33 @@ NOTE: This call is for debug purposes only and is unstable as returned objects m
 **Request objects:**
 ```json
 {
-    "action": "stats",
-    "type": "objects"
+  "action": "stats",
+  "type": "objects"
 }
 ```
 
 **Objects response:**
 ```json
 {
-    "node": {
-        "ledger": {
-            "bootstrap_weights": {
-                "count": "125",
-                "size": "7000"
-            }
-        },
-        "peers": {
-            "peers": {
-                "count": "38",
-                "size": "7296"
-            },
-            "attempts": {
-                "count": "95",
-                "size": "3800"
-            },
-        },
-        ...
-    }
+  "node": {
+    "ledger": {
+      "bootstrap_weights": {
+        "count": "125",
+        "size": "7000"
+      }
+    },
+    "peers": {
+      "peers": {
+        "count": "38",
+        "size": "7296"
+      },
+      "attempts": {
+        "count": "95",
+        "size": "3800"
+      },
+    },
+    ...
+  }
 }
 ```
 
@@ -2112,8 +2154,8 @@ Clears all collected statistics. The "stat_duration_seconds" value in the "stats
 ```  
 **Response:**
 ```json
-{  
-  "success": ""  
+{
+  "success": ""
 }
 ```
 
@@ -2125,14 +2167,14 @@ Method to safely shutdown node
 
 **Request:**
 ```json
-{  
-  "action": "stop"  
+{
+  "action": "stop"
 }
 ```  
 **Response:**
 ```json
-{  
-  "success": ""  
+{
+  "success": ""
 }
 ```  
 
@@ -2143,18 +2185,18 @@ Returns a list of block hashes in the account chain starting at **block** up to 
 
 **Request:**
 ```json
-{  
+{
   "action": "successors",
-  "block": "991CF190094C00F0B68E2E5F75F6BEE95A2E0BD93CEAA4A6734DB9F19B728948",  
-  "count": "1"    
+  "block": "991CF190094C00F0B68E2E5F75F6BEE95A2E0BD93CEAA4A6734DB9F19B728948",
+  "count": "1"
 }
 ```  
 **Response:**
 ```json
-{    
-  "blocks" : [  
-  "991CF190094C00F0B68E2E5F75F6BEE95A2E0BD93CEAA4A6734DB9F19B728948"  
-  ]  
+{
+  "blocks" : [
+    "991CF190094C00F0B68E2E5F75F6BEE95A2E0BD93CEAA4A6734DB9F19B728948"
+  ]
 }
 ```
 **Optional "offset"**
@@ -2174,14 +2216,14 @@ Check whether **account** is a valid account number using checksum
 
 **Request:**
 ```json
-{  
-  "action": "validate_account_number",  
-  "account": "nano_1111111111111111111111111111111111111111111111111117353trpda"  
+{
+  "action": "validate_account_number",
+  "account": "nano_1111111111111111111111111111111111111111111111111117353trpda"
 }
 ```  
 **Response:**
 ```json
-{  
+{
   "valid" : "1"
 }
 ```
@@ -2195,8 +2237,8 @@ _RPC Version always returns "1" as of 01/11/2018_
 
 **Request:**
 ```json
-{  
-  "action": "version" 
+{
+  "action": "version"
 }
 ```  
 **Response:**
@@ -2216,31 +2258,31 @@ _RPC Version always returns "1" as of 01/11/2018_
 
 ### unchecked  
 _version 8.0+_   
-Returns a list of pairs of unchecked synchronizing block hash and its json representation up to **count**          
+Returns a list of pairs of unchecked block hashes and their json representation up to **count**.
 
 **Request:**
 ```json
-{  
+{
   "action": "unchecked",
-  "count": "1" 
+  "count": "1"
 }
 ```  
 **Response:**
 ```json
-{  
-    "blocks": {  
-       "87434F8041869A01C8F6F263B87972D7BA443A72E0A97D7A3FD0CCC2358FD6F9": "{\n    
-         \"type\": \"state\",\n
-         \"account\": \"nano_1ipx847tk8o46pwxt5qjdbncjqcbwcc1rrmqnkztrfjy5k7z4imsrata9est\",\n    
-         \"previous\": \"CE898C131AAEE25E05362F247760F8A3ACF34A9796A5AE0D9204E86B0637965E\",\n    
-         \"representative\": \"nano_1stofnrxuz3cai7ze75o174bpm7scwj9jn3nxsn8ntzg784jf1gzn1jjdkou\",\n    
-         \"balance\": \"5606157000000000000000000000000000000\",\n    
-         \"link\": \"5D1AA8A45F8736519D707FCB375976A7F9AF795091021D7E9C7548D6F45DD8D5\",\n    
-         \"link_as_account\": \"nano_1qato4k7z3spc8gq1zyd8xeqfbzsoxwo36a45ozbrxcatut7up8ohyardu1z\",\n    
-         \"signature\": \"82D41BC16F313E4B2243D14DFFA2FB04679C540C2095FEE7EAE0F2F26880AD56DD48D87A7CC5DD760C5B2D76EE2C205506AA557BF00B60D8DEE312EC7343A501\",\n      
-         \"work\": \"8a142e07a10996d5\"\n     
-      }\n"
-    }
+{
+  "blocks": {
+     "87434F8041869A01C8F6F263B87972D7BA443A72E0A97D7A3FD0CCC2358FD6F9": "{\n
+       \"type\": \"state\",\n
+       \"account\": \"nano_1ipx847tk8o46pwxt5qjdbncjqcbwcc1rrmqnkztrfjy5k7z4imsrata9est\",\n
+       \"previous\": \"CE898C131AAEE25E05362F247760F8A3ACF34A9796A5AE0D9204E86B0637965E\",\n
+       \"representative\": \"nano_1stofnrxuz3cai7ze75o174bpm7scwj9jn3nxsn8ntzg784jf1gzn1jjdkou\",\n
+       \"balance\": \"5606157000000000000000000000000000000\",\n
+       \"link\": \"5D1AA8A45F8736519D707FCB375976A7F9AF795091021D7E9C7548D6F45DD8D5\",\n
+       \"link_as_account\": \"nano_1qato4k7z3spc8gq1zyd8xeqfbzsoxwo36a45ozbrxcatut7up8ohyardu1z\",\n
+       \"signature\": \"82D41BC16F313E4B2243D14DFFA2FB04679C540C2095FEE7EAE0F2F26880AD56DD48D87A7CC5DD760C5B2D76EE2C205506AA557BF00B60D8DEE312EC7343A501\",\n
+       \"work\": \"8a142e07a10996d5\"\n
+    }\n"
+  }
 }
 ```
 
@@ -2252,14 +2294,14 @@ Clear unchecked synchronizing blocks
 
 **Request:**
 ```json
-{  
-    "action": "unchecked_clear"   
+{
+    "action": "unchecked_clear"
 }
 ```  
 **Response:**
 ```json
-{  
-    "success": ""  
+{
+    "success": ""
 }
 ```  
 
@@ -2267,29 +2309,31 @@ Clear unchecked synchronizing blocks
 
 ### unchecked_get  
 _version 8.0+_  
-Retrieves a json representation of unchecked synchronizing block by **hash**     
+Retrieves a json representation of unchecked synchronizing block by **hash**. Using the optional `json_block` is recommended since v19.0.  
 
 **Request:**
 ```json
-{  
-  "action": "unchecked_get",  
-  "hash": "87434F8041869A01C8F6F263B87972D7BA443A72E0A97D7A3FD0CCC2358FD6F9"  
+{
+  "action": "unchecked_get",
+  "json_block": "true",
+  "hash": "19BF0C268C2D9AED1A8C02E40961B67EA56B1681DE274CD0C50F3DD972F0655C"
 }
 ```  
 **Response:**
 ```json
-{  
-  "contents" : "{\n    
-         \"type\": \"state\",\n
-         \"account\": \"nano_1ipx847tk8o46pwxt5qjdbncjqcbwcc1rrmqnkztrfjy5k7z4imsrata9est\",\n    
-         \"previous\": \"CE898C131AAEE25E05362F247760F8A3ACF34A9796A5AE0D9204E86B0637965E\",\n    
-         \"representative\": \"nano_1stofnrxuz3cai7ze75o174bpm7scwj9jn3nxsn8ntzg784jf1gzn1jjdkou\",\n    
-         \"balance\": \"5606157000000000000000000000000000000\",\n    
-         \"link\": \"5D1AA8A45F8736519D707FCB375976A7F9AF795091021D7E9C7548D6F45DD8D5\",\n    
-         \"link_as_account\": \"nano_1qato4k7z3spc8gq1zyd8xeqfbzsoxwo36a45ozbrxcatut7up8ohyardu1z\",\n    
-         \"signature\": \"82D41BC16F313E4B2243D14DFFA2FB04679C540C2095FEE7EAE0F2F26880AD56DD48D87A7CC5DD760C5B2D76EE2C205506AA557BF00B60D8DEE312EC7343A501\",\n    
-        \"work\": \"8a142e07a10996d5\"\n    
-  }\n"
+{
+  "modified_timestamp": "1565856525",
+  "contents": {
+    "type": "state",
+    "account": "nano_1hmqzugsmsn4jxtzo5yrm4rsysftkh9343363hctgrjch1984d8ey9zoyqex",
+    "previous": "009C587914611E83EE7F75BD9C000C430C720D0364D032E84F37678D7D012911",
+    "representative": "nano_1stofnrxuz3cai7ze75o174bpm7scwj9jn3nxsn8ntzg784jf1gzn1jjdkou",
+    "balance": "189012679592109992600249228",
+    "link": "0000000000000000000000000000000000000000000000000000000000000000",
+    "link_as_account": "nano_1111111111111111111111111111111111111111111111111111hifc8npp",
+    "signature": "845C8660750895843C013CE33E31B80EF0A7A69E52DDAF74A5F1BDFAA9A52E4D9EA2C3BE1AB0BD5790FCC1AD9B7A3D2F4B44EECE4279A8184D414A30A1B4620F",
+    "work": "0dfb32653e189699"
+  }
 }
 ```
 **Optional "json_block"**
@@ -2301,36 +2345,38 @@ Default "false". If "true", "contents" will contain a JSON subtree instead of a 
 
 ### unchecked_keys   
 _version 8.0+_   
-Retrieves unchecked database keys, blocks hashes & a json representations of unchecked pending blocks starting from **key** up to **count**   
+Retrieves unchecked database keys, blocks hashes & a json representations of unchecked pending blocks starting from **key** up to **count**.Using the optional `json_block` is recommended since v19.0.   
 
 **Request:**
 ```json
-{  
+{
   "action": "unchecked_keys",
-  "key": "CE898C131AAEE25E05362F247760F8A3ACF34A9796A5AE0D9204E86B0637965E",   
-  "count": "1" 
+  "json_block": "true",
+  "key": "19BF0C268C2D9AED1A8C02E40961B67EA56B1681DE274CD0C50F3DD972F0655C",
+  "count": "1"
 }
 ```  
 **Response:**
 ```json
-{  
-    "unchecked": [
-       { 
-          "key": "CE898C131AAEE25E05362F247760F8A3ACF34A9796A5AE0D9204E86B0637965E",   
-          "hash": "87434F8041869A01C8F6F263B87972D7BA443A72E0A97D7A3FD0CCC2358FD6F9",   
-          "contents": "{\n    
-             \"type\": \"state\",\n
-             \"account\": \"nano_1ipx847tk8o46pwxt5qjdbncjqcbwcc1rrmqnkztrfjy5k7z4imsrata9est\",\n    
-             \"previous\": \"CE898C131AAEE25E05362F247760F8A3ACF34A9796A5AE0D9204E86B0637965E\",\n    
-             \"representative\": \"nano_1stofnrxuz3cai7ze75o174bpm7scwj9jn3nxsn8ntzg784jf1gzn1jjdkou\",\n    
-             \"balance\": \"5606157000000000000000000000000000000\",\n    
-             \"link\": \"5D1AA8A45F8736519D707FCB375976A7F9AF795091021D7E9C7548D6F45DD8D5\",\n    
-             \"link_as_account\": \"nano_1qato4k7z3spc8gq1zyd8xeqfbzsoxwo36a45ozbrxcatut7up8ohyardu1z\",\n    
-             \"signature\": \"82D41BC16F313E4B2243D14DFFA2FB04679C540C2095FEE7EAE0F2F26880AD56DD48D87A7CC5DD760C5B2D76EE2C205506AA557BF00B60D8DEE312EC7343A501\",\n    
-            \"work\": \"8a142e07a10996d5\"\n    
-         }\n"   
-       }   
-    ]   
+{
+  "unchecked": [
+    {
+      "key": "19BF0C268C2D9AED1A8C02E40961B67EA56B1681DE274CD0C50F3DD972F0655C",
+      "hash": "A1A8558CBABD3F7C1D70F8CB882355F2EF688E7F30F5FDBD0204CAE157885056",
+      "modified_timestamp": "1565856744",
+      "contents": {
+        "type": "state",
+        "account": "nano_1hmqzugsmsn4jxtzo5yrm4rsysftkh9343363hctgrjch1984d8ey9zoyqex",
+        "previous": "19BF0C268C2D9AED1A8C02E40961B67EA56B1681DE274CD0C50F3DD972F0655C",
+        "representative": "nano_1stofnrxuz3cai7ze75o174bpm7scwj9jn3nxsn8ntzg784jf1gzn1jjdkou",
+        "balance": "189012679592109992600249226",
+        "link": "0000000000000000000000000000000000000000000000000000000000000000",
+        "link_as_account": "nano_1111111111111111111111111111111111111111111111111111hifc8npp",
+        "signature": "FF5D49925AD3C8705E6EEDD993E8C4120E6107D7F1CB53B287773448DEA0B1D32918E67804248FC83609F0D93401D833DFA33127F21B6CD02F75D6E31A00450A",
+        "work": "8193ddf00947e694"
+      }
+    }
+  ]
 }
 ```   
 
@@ -2349,20 +2395,20 @@ Returns the total pending balance for unopened accounts in the local database, s
 
 **Request:**
 ```json
-  {   
-    "action": "unopened",   
-    "account": "nano_1111111111111111111111111111111111111111111111111111hifc8npp",   
-    "count": "1"   
-  }   
+{
+  "action": "unopened",
+  "account": "nano_1111111111111111111111111111111111111111111111111111hifc8npp",
+  "count": "1"
+}
 ```   
 
 **Response:**
 ```json 
-  {   
-    "accounts": {   
-      "nano_1111111111111111111111111111111111111111111111111111hifc8npp": "207034077034226183413773082289554618448"   
-    }   
-  }   
+{
+  "accounts": {
+    "nano_1111111111111111111111111111111111111111111111111111hifc8npp": "207034077034226183413773082289554618448"
+  }
+}
 ```   
 
 **Optional "threshold"**  
@@ -2376,13 +2422,13 @@ Return node uptime in seconds
 
 **Request:**
 ```json
-{  
-  "action": "uptime"  
+{
+  "action": "uptime"
 }
 ```  
 **Response:**
 ```json
-{  
+{
     "seconds": "6000"
 }
 ```  
@@ -2395,14 +2441,14 @@ Stop generating **work** for block
 
 **Request:**
 ```json
-{  
-    "action": "work_cancel",  
-    "hash": "718CC2121C3E641059BC1C2CFC45666C99E8AE922F7A807B7D07B62C995D79E2"  
+{
+  "action": "work_cancel",
+  "hash": "718CC2121C3E641059BC1C2CFC45666C99E8AE922F7A807B7D07B62C995D79E2"
 }
 ```  
 **Response:**
 ```json
-{  
+{
 }
 ```  
 
@@ -2414,18 +2460,18 @@ Generates **work** for block. **hash** is the frontier of the account or in the 
 
 **Request:**
 ```json
-{  
-    "action": "work_generate",  
-    "hash": "718CC2121C3E641059BC1C2CFC45666C99E8AE922F7A807B7D07B62C995D79E2",
-    "difficulty": "ffffffd21c3933f3"
+{
+  "action": "work_generate",
+  "hash": "718CC2121C3E641059BC1C2CFC45666C99E8AE922F7A807B7D07B62C995D79E2",
+  "difficulty": "ffffffd21c3933f3"
 }
 ```  
 **Response:**
 ```json
-{  
-    "work": "2bf29ef00786a6bc",
-    "difficulty": "ffffffd21c3933f4",
-    "multiplier": "1.394647" 
+{
+  "work": "2bf29ef00786a6bc",
+  "difficulty": "ffffffd21c3933f4",
+  "multiplier": "1.394647"
 }
 ```  
 
@@ -2454,16 +2500,16 @@ Add specific **IP address** and **port** as work peer for node until restart
 
 **Request:**
 ```json
-{  
-    "action": "work_peer_add",  
-    "address": "::ffff:172.17.0.1",  
-    "port": "7076" 
+{
+  "action": "work_peer_add",
+  "address": "::ffff:172.17.0.1",
+  "port": "7076"
 }
 ```  
 **Response:**
 ```json
-{  
-    "success": ""  
+{
+  "success": ""
 }
 ```  
 
@@ -2474,16 +2520,16 @@ _enable_control required, version 8.0+_
 
 **Request:**
 ```json
-{  
-    "action": "work_peers"   
+{
+  "action": "work_peers"
 }
 ```  
 **Response:**
 ```json
-{  
-    "work_peers": [   
-        "::ffff:172.17.0.1:7076"   
-    ]   
+{
+  "work_peers": [
+    "::ffff:172.17.0.1:7076"
+  ]
 }
 ```  
 
@@ -2495,14 +2541,14 @@ Clear work peers node list until restart
 
 **Request:**
 ```json
-{  
-    "action": "work_peers_clear"   
+{
+  "action": "work_peers_clear"
 }
 ```  
 **Response:**
 ```json
-{  
-    "success": ""  
+{
+  "success": ""
 }
 ```  
 
@@ -2513,19 +2559,19 @@ Check whether **work** is valid for block
 
 **Request:**
 ```json
-{  
-    "action": "work_validate",  
-    "work": "2bf29ef00786a6bc",  
-    "hash": "718CC2121C3E641059BC1C2CFC45666C99E8AE922F7A807B7D07B62C995D79E2",
-    "difficulty": "ffffffd21c3933f3"
+{
+  "action": "work_validate",
+  "work": "2bf29ef00786a6bc",
+  "hash": "718CC2121C3E641059BC1C2CFC45666C99E8AE922F7A807B7D07B62C995D79E2",
+  "difficulty": "ffffffd21c3933f3"
 }
 ```  
 **Response:**
 ```json
-{  
-    "valid": "1",
-    "difficulty": "ffffffd21c3933f4",
-    "multiplier": "1.394647"  
+{
+  "valid": "1",
+  "difficulty": "ffffffd21c3933f4",
+  "multiplier": "1.394647"
 }
 ```
 
@@ -2557,16 +2603,16 @@ Creates a new account, insert next deterministic key in **wallet**
 
 **Request:**
 ```json
-{  
-  "action": "account_create",  
-  "wallet": "000D1BAEC8EC208142C99059B393051BAC8380F9B5A2E6B2489A277D81789F3F"  
+{
+  "action": "account_create",
+  "wallet": "000D1BAEC8EC208142C99059B393051BAC8380F9B5A2E6B2489A277D81789F3F"
 }
 ```
   
 **Response:**
 ```json
-{  
-  "account" : "nano_3e3j5tkog48pnny9dmfzj1r16pg8t1e76dz5tmac6iq689wyjfpi00000000"  
+{
+  "account": "nano_3e3j5tkog48pnny9dmfzj1r16pg8t1e76dz5tmac6iq689wyjfpi00000000"
 }
 ```
 **Optional "index"**
@@ -2576,9 +2622,9 @@ unset by default. Indicates which index to create account for starting with 0
 
 **Request:**
 ```json
-{  
-  "action": "account_create",  
-  "wallet": "000D1BAEC8EC208142C99059B393051BAC8380F9B5A2E6B2489A277D81789F3F",  
+{
+  "action": "account_create",
+  "wallet": "000D1BAEC8EC208142C99059B393051BAC8380F9B5A2E6B2489A277D81789F3F",
   "index": "1"
 }
 ```
@@ -2590,10 +2636,10 @@ Boolean, true by default. Setting false disables work generation after creating 
 
 **Request:**
 ```json
-{  
-  "action": "account_create",  
-  "wallet": "000D1BAEC8EC208142C99059B393051BAC8380F9B5A2E6B2489A277D81789F3F",  
-  "work": "false"  
+{
+  "action": "account_create",
+  "wallet": "000D1BAEC8EC208142C99059B393051BAC8380F9B5A2E6B2489A277D81789F3F",
+  "work": "false"
 }
 ```
 
@@ -2604,16 +2650,16 @@ Lists all the accounts inside **wallet**
 
 **Request:**
 ```json
-{  
-  "action": "account_list",  
-  "wallet": "000D1BAEC8EC208142C99059B393051BAC8380F9B5A2E6B2489A277D81789F3F"  
+{
+  "action": "account_list",
+  "wallet": "000D1BAEC8EC208142C99059B393051BAC8380F9B5A2E6B2489A277D81789F3F"
 }
 ```  
 **Response:**
 ```json
-{  
-  "accounts" : [
-  "nano_3e3j5tkog48pnny9dmfzj1r16pg8t1e76dz5tmac6iq689wyjfpi00000000"  
+{
+  "accounts": [
+    "nano_3e3j5tkog48pnny9dmfzj1r16pg8t1e76dz5tmac6iq689wyjfpi00000000"
   ]
 }
 ```
@@ -2626,18 +2672,18 @@ Moves **accounts** from **source** to **wallet**
 
 **Request:**
 ```json
-{  
-  "action": "account_move",  
-  "wallet": "000D1BAEC8EC208142C99059B393051BAC8380F9B5A2E6B2489A277D81789F3F",  
-  "source": "000D1BAEC8EC208142C99059B393051BAC8380F9B5A2E6B2489A277D81789F3F",  
-  "accounts" : [  
-  "nano_3e3j5tkog48pnny9dmfzj1r16pg8t1e76dz5tmac6iq689wyjfpi00000000"  
-  ]  
+{
+  "action": "account_move",
+  "wallet": "000D1BAEC8EC208142C99059B393051BAC8380F9B5A2E6B2489A277D81789F3F",
+  "source": "000D1BAEC8EC208142C99059B393051BAC8380F9B5A2E6B2489A277D81789F3F",
+  "accounts": [
+    "nano_3e3j5tkog48pnny9dmfzj1r16pg8t1e76dz5tmac6iq689wyjfpi00000000"
+  ]
 }
 ```  
 **Response:**
 ```json
-{  
+{
   "moved" : "1"
 }
 ```
@@ -2650,15 +2696,15 @@ Remove **account** from **wallet**
 
 **Request:**
 ```json
-{  
-  "action": "account_remove",  
-  "wallet": "000D1BAEC8EC208142C99059B393051BAC8380F9B5A2E6B2489A277D81789F3F",  
+{
+  "action": "account_remove",
+  "wallet": "000D1BAEC8EC208142C99059B393051BAC8380F9B5A2E6B2489A277D81789F3F",
   "account": "nano_39a73oy5ungrhxy5z5oao1xso4zo7dmgpjd4u74xcrx3r1w6rtazuouw6qfi"
 }
 ```  
 **Response:**
 ```json
-{  
+{
   "removed": "1"
 }
 ```
@@ -2671,16 +2717,16 @@ Sets the representative for **account** in **wallet**
 
 **Request:**
 ```json
-{  
-  "action": "account_representative_set",  
-  "wallet": "000D1BAEC8EC208142C99059B393051BAC8380F9B5A2E6B2489A277D81789F3F",  
-  "account": "nano_39a73oy5ungrhxy5z5oao1xso4zo7dmgpjd4u74xcrx3r1w6rtazuouw6qfi",  
-  "representative" : "nano_16u1uufyoig8777y6r8iqjtrw8sg8maqrm36zzcm95jmbd9i9aj5i8abr8u5"
+{
+  "action": "account_representative_set",
+  "wallet": "000D1BAEC8EC208142C99059B393051BAC8380F9B5A2E6B2489A277D81789F3F",
+  "account": "nano_39a73oy5ungrhxy5z5oao1xso4zo7dmgpjd4u74xcrx3r1w6rtazuouw6qfi",
+  "representative": "nano_16u1uufyoig8777y6r8iqjtrw8sg8maqrm36zzcm95jmbd9i9aj5i8abr8u5"
 }
 ```  
 **Response:**
 ```json
-{  
+{
   "block": "000D1BAEC8EC208142C99059B393051BAC8380F9B5A2E6B2489A277D81789F3F"
 }
 ```
@@ -2697,19 +2743,19 @@ Creates new accounts, insert next deterministic keys in **wallet** up to **count
 
 **Request:**
 ```json
-{  
-  "action": "accounts_create",  
-  "wallet": "000D1BAEC8EC208142C99059B393051BAC8380F9B5A2E6B2489A277D81789F3F",  
+{
+  "action": "accounts_create",
+  "wallet": "000D1BAEC8EC208142C99059B393051BAC8380F9B5A2E6B2489A277D81789F3F",
   "count": "2"
 }
 ```  
 **Response:**
 ```json
-{  
-  "accounts": [    
-     "nano_3e3j5tkog48pnny9dmfzj1r16pg8t1e76dz5tmac6iq689wyjfpi00000000",   
-     "nano_1e5aqegc1jb7qe964u4adzmcezyo6o146zb8hm6dft8tkp79za3s00000000"
-  ]   
+{
+  "accounts": [
+    "nano_3e3j5tkog48pnny9dmfzj1r16pg8t1e76dz5tmac6iq689wyjfpi00000000",
+    "nano_1e5aqegc1jb7qe964u4adzmcezyo6o146zb8hm6dft8tkp79za3s00000000"
+  ]
 }
 ```
 **Optional enabling work generation**  
@@ -2718,11 +2764,11 @@ Boolean, false by default. Enables work generation after creating accounts
 
 **Request:**
 ```json
-{  
-  "action": "accounts_create",  
-  "wallet": "000D1BAEC8EC208142C99059B393051BAC8380F9B5A2E6B2489A277D81789F3F",  
-  "count": "2",  
-  "work": "true"  
+{
+  "action": "accounts_create",
+  "wallet": "000D1BAEC8EC208142C99059B393051BAC8380F9B5A2E6B2489A277D81789F3F",
+  "count": "2",
+  "work": "true"
 }
 ```  
 ***Note:*** Before version 11.2 work generation was enabled by default, if you want to disable work generation for previous versions, use "work": "false"
@@ -2740,15 +2786,15 @@ Changes the password for **wallet** to **password**
 
 **Request:**
 ```json
-{  
-  "action": "password_change",  
-  "wallet": "000D1BAEC8EC208142C99059B393051BAC8380F9B5A2E6B2489A277D81789F3F",  
-  "password": "test"  
+{
+  "action": "password_change",
+  "wallet": "000D1BAEC8EC208142C99059B393051BAC8380F9B5A2E6B2489A277D81789F3F",
+  "password": "test"
 }
 ```  
 **Response:**
 ```json
-{  
+{
   "changed" : "1"
 }
 ```
@@ -2760,16 +2806,16 @@ Enters the **password** in to **wallet** to unlock it
 
 **Request:**
 ```json
-{  
-  "action": "password_enter",  
-  "wallet": "000D1BAEC8EC208142C99059B393051BAC8380F9B5A2E6B2489A277D81789F3F",  
-  "password": "test"  
+{
+  "action": "password_enter",
+  "wallet": "000D1BAEC8EC208142C99059B393051BAC8380F9B5A2E6B2489A277D81789F3F",
+  "password": "test"
 }
 ```  
 **Response:**
 ```json
-{  
-  "valid" : "1"
+{
+  "valid": "1"
 }
 ```
 
@@ -2780,14 +2826,14 @@ Checks whether the password entered for **wallet** is valid
 
 **Request:**
 ```json
-{  
-  "action": "password_valid",  
-  "wallet": "000D1BAEC8EC208142C99059B393051BAC8380F9B5A2E6B2489A277D81789F3F"  
+{
+  "action": "password_valid",
+  "wallet": "000D1BAEC8EC208142C99059B393051BAC8380F9B5A2E6B2489A277D81789F3F"
 }
 ```  
 **Response:**
 ```json
-{  
+{
   "valid" : "1"
 }
 ```
@@ -2800,17 +2846,17 @@ Receive pending **block** for **account** in **wallet**
 
 **Request:**
 ```json
-{  
-  "action": "receive",  
-  "wallet": "000D1BAEC8EC208142C99059B393051BAC8380F9B5A2E6B2489A277D81789F3F",  
-  "account": "nano_3e3j5tkog48pnny9dmfzj1r16pg8t1e76dz5tmac6iq689wyjfpi00000000",  
-  "block": "53EAA25CE28FA0E6D55EA9704B32604A736966255948594D55CBB05267CECD48"  
+{
+  "action": "receive",
+  "wallet": "000D1BAEC8EC208142C99059B393051BAC8380F9B5A2E6B2489A277D81789F3F",
+  "account": "nano_3e3j5tkog48pnny9dmfzj1r16pg8t1e76dz5tmac6iq689wyjfpi00000000",
+  "block": "53EAA25CE28FA0E6D55EA9704B32604A736966255948594D55CBB05267CECD48"
 }
 ```  
 **Response:**
 ```json
-{  
-  "block": "EE5286AB32F580AB65FD84A69E107C69FBEB571DEC4D99297E19E3FA5529547B"  
+{
+  "block": "EE5286AB32F580AB65FD84A69E107C69FBEB571DEC4D99297E19E3FA5529547B"
 }
 ```
 **Optional "work"**
@@ -2826,14 +2872,14 @@ Returns receive minimum for node wallet
 
 **Request:**
 ```json
-{  
-  "action": "receive_minimum"  
+{
+  "action": "receive_minimum"
 }
 ```  
 **Response:**
 ```json
-{  
-  "amount": "1000000000000000000000000"  
+{
+  "amount": "1000000000000000000000000"
 }
 ```
 
@@ -2845,15 +2891,15 @@ Set **amount** as new receive minimum for node wallet until restart
 
 **Request:**
 ```json
-{  
-  "action": "receive_minimum_set",  
+{
+  "action": "receive_minimum_set",
   "amount": "1000000000000000000000000000000"
 }
 ```  
 **Response:**
 ```json
-{  
-  "success": ""  
+{
+  "success": ""
 }
 ```
 
@@ -2865,15 +2911,15 @@ Tells the node to look for pending blocks for any account in **wallet**
 
 **Request:**
 ```json
-{  
-  "action": "search_pending",  
+{
+  "action": "search_pending",
   "wallet": "000D1BAEC8EC208142C99059B393051BAC8380F9B5A2E6B2489A277D81789F3F"
 }
 ```  
 **Response:**
 ```json
 {
-  "started": "1"  
+  "started": "1"
 }
 ```
 
@@ -2886,7 +2932,7 @@ Tells the node to look for pending blocks for any account in all available walle
 
 **Request:**
 ```json
-{  
+{
   "action": "search_pending_all"
 }
 ```  
@@ -2905,18 +2951,18 @@ Send **amount** from **source** in **wallet** to **destination**
 
 **Request:**
 ```json
-{  
-  "action": "send",  
-  "wallet": "000D1BAEC8EC208142C99059B393051BAC8380F9B5A2E6B2489A277D81789F3F",  
-  "source": "nano_3e3j5tkog48pnny9dmfzj1r16pg8t1e76dz5tmac6iq689wyjfpi00000000",  
+{
+  "action": "send",
+  "wallet": "000D1BAEC8EC208142C99059B393051BAC8380F9B5A2E6B2489A277D81789F3F",
+  "source": "nano_3e3j5tkog48pnny9dmfzj1r16pg8t1e76dz5tmac6iq689wyjfpi00000000",
   "destination": "nano_3e3j5tkog48pnny9dmfzj1r16pg8t1e76dz5tmac6iq689wyjfpi00000000",
-  "amount": "1000000"  
+  "amount": "1000000"
 }
 ```  
 **Response:**
 ```json
-{  
-  "block": "000D1BAEC8EC208142C99059B393051BAC8380F9B5A2E6B2489A277D81789F3F"  
+{
+  "block": "000D1BAEC8EC208142C99059B393051BAC8380F9B5A2E6B2489A277D81789F3F"
 }
 ```
 Proof of Work is precomputed for **one** transaction in the background when you are using the node wallet to track accounts.  If it has been a while since your last transaction it will send instantly, the next one will need to wait for Proof of Work to be generated.
@@ -2936,10 +2982,10 @@ Using the same id for requests with different parameters (wallet, source, destin
 
 **Request:**
 ```json
-{  
-  "action": "send",  
-  "wallet": "000D1BAEC8EC208142C99059B393051BAC8380F9B5A2E6B2489A277D81789F3F",  
-  "source": "nano_3e3j5tkog48pnny9dmfzj1r16pg8t1e76dz5tmac6iq689wyjfpi00000000",  
+{
+  "action": "send",
+  "wallet": "000D1BAEC8EC208142C99059B393051BAC8380F9B5A2E6B2489A277D81789F3F",
+  "source": "nano_3e3j5tkog48pnny9dmfzj1r16pg8t1e76dz5tmac6iq689wyjfpi00000000",
   "destination": "nano_3e3j5tkog48pnny9dmfzj1r16pg8t1e76dz5tmac6iq689wyjfpi00000000",
   "amount": "1000000",
   "id": "7081e2b8fec9146e"
@@ -2947,8 +2993,8 @@ Using the same id for requests with different parameters (wallet, source, destin
 ```  
 **Response:**
 ```json
-{  
-  "block": "000D1BAEC8EC208142C99059B393051BAC8380F9B5A2E6B2489A277D81789F3F"  
+{
+  "block": "000D1BAEC8EC208142C99059B393051BAC8380F9B5A2E6B2489A277D81789F3F"
 }
 ```
 
@@ -2961,13 +3007,13 @@ Work value (16 hexadecimal digits string, 64 bit). Uses **work** value for block
 
 **Request:**
 ```json
-{  
-  "action": "send",  
-  "wallet": "000D1BAEC8EC208142C99059B393051BAC8380F9B5A2E6B2489A277D81789F3F",  
-  "source": "nano_3e3j5tkog48pnny9dmfzj1r16pg8t1e76dz5tmac6iq689wyjfpi00000000",  
+{
+  "action": "send",
+  "wallet": "000D1BAEC8EC208142C99059B393051BAC8380F9B5A2E6B2489A277D81789F3F",
+  "source": "nano_3e3j5tkog48pnny9dmfzj1r16pg8t1e76dz5tmac6iq689wyjfpi00000000",
   "destination": "nano_3e3j5tkog48pnny9dmfzj1r16pg8t1e76dz5tmac6iq689wyjfpi00000000",
-  "amount": "1000000",   
-  "work": "2bf29ef00786a6bc"   
+  "amount": "1000000",
+  "work": "2bf29ef00786a6bc"
 }
 ```  
 
@@ -2984,16 +3030,16 @@ Add an adhoc private key **key** to **wallet**
 
 **Request:**
 ```json
-{  
-  "action": "wallet_add",  
-  "wallet": "000D1BAEC8EC208142C99059B393051BAC8380F9B5A2E6B2489A277D81789F3F",  
-  "key": "34F0A37AAD20F4A260F0A5B3CB3D7FB50673212263E58A380BC10474BB039CE4"  
+{
+  "action": "wallet_add",
+  "wallet": "000D1BAEC8EC208142C99059B393051BAC8380F9B5A2E6B2489A277D81789F3F",
+  "key": "34F0A37AAD20F4A260F0A5B3CB3D7FB50673212263E58A380BC10474BB039CE4"
 }
 ```  
 **Response:**
 ```json
-{  
-  "account" : "nano_3e3j5tkog48pnny9dmfzj1r16pg8t1e76dz5tmac6iq689wyjfpi00000000"
+{
+  "account": "nano_3e3j5tkog48pnny9dmfzj1r16pg8t1e76dz5tmac6iq689wyjfpi00000000"
 }
 ```
 **Optional disabling work generation**
@@ -3003,11 +3049,11 @@ Boolean, false by default. Disables work generation after adding account
 
 **Request:**
 ```json
-{  
-  "action": "wallet_add",  
-  "wallet": "000D1BAEC8EC208142C99059B393051BAC8380F9B5A2E6B2489A277D81789F3F",  
-  "key": "34F0A37AAD20F4A260F0A5B3CB3D7FB50673212263E58A380BC10474BB039CE4",  
-  "work": "false"  
+{
+  "action": "wallet_add",
+  "wallet": "000D1BAEC8EC208142C99059B393051BAC8380F9B5A2E6B2489A277D81789F3F",
+  "key": "34F0A37AAD20F4A260F0A5B3CB3D7FB50673212263E58A380BC10474BB039CE4",
+  "work": "false"
 }
 ```  
 
@@ -3019,18 +3065,18 @@ Add watch-only **accounts** to **wallet**
 
 **Request:**
 ```json
-{  
-  "action": "wallet_add_watch",  
-  "wallet": "000D1BAEC8EC208142C99059B393051BAC8380F9B5A2E6B2489A277D81789F3F",  
+{
+  "action": "wallet_add_watch",
+  "wallet": "000D1BAEC8EC208142C99059B393051BAC8380F9B5A2E6B2489A277D81789F3F",
   "accounts": [
     "nano_3e3j5tkog48pnny9dmfzj1r16pg8t1e76dz5tmac6iq689wyjfpi00000000",
     "nano_111111111111111111111111111111111111111111111111111000000000"
-  ]  
+  ]
 }
 ```  
 **Response:**
 ```json
-{  
+{
   "success" : ""
 }
 ```
@@ -3044,20 +3090,20 @@ Returns how many raw is owned and how many have not yet been received by all acc
 
 **Request:**
 ```json
-{  
-  "action": "wallet_balances",  
-  "wallet": "000D1BAEC8EC208142C99059B393051BAC8380F9B5A2E6B2489A277D81789F3F"  
+{
+  "action": "wallet_balances",
+  "wallet": "000D1BAEC8EC208142C99059B393051BAC8380F9B5A2E6B2489A277D81789F3F"
 }
 ```  
 **Response:**
 ```json
-{  
-  "balances" : {  
-    "nano_3e3j5tkog48pnny9dmfzj1r16pg8t1e76dz5tmac6iq689wyjfpi00000000": {  
-      "balance": "10000",  
-      "pending": "10000"  
+{
+  "balances" : {
+    "nano_3e3j5tkog48pnny9dmfzj1r16pg8t1e76dz5tmac6iq689wyjfpi00000000": {
+      "balance": "10000",
+      "pending": "10000"
     }
-  }   
+  }
 }
 ```
 **Optional "threshold"**
@@ -3074,17 +3120,17 @@ Changes seed for **wallet** to **seed**.  ***Notes:*** Clear all deterministic a
 
 **Request:**
 ```json
-{  
-  "action": "wallet_change_seed",  
-  "wallet": "000D1BAEC8EC208142C99059B393051BAC8380F9B5A2E6B2489A277D81789F3F",  
-  "seed": "74F2B37AAD20F4A260F0A5B3CB3D7FB51673212263E58A380BC10474BB039CEE"  
+{
+  "action": "wallet_change_seed",
+  "wallet": "000D1BAEC8EC208142C99059B393051BAC8380F9B5A2E6B2489A277D81789F3F",
+  "seed": "74F2B37AAD20F4A260F0A5B3CB3D7FB51673212263E58A380BC10474BB039CEE"
 }
 ```  
 **Response:**
 ```json
-{  
-  "success" : "",  
-  "last_restored_account": "nano_1mhdfre3zczr86mp44jd3xft1g1jg66jwkjtjqixmh6eajfexxti7nxcot9c",  
+{
+  "success" : "",
+  "last_restored_account": "nano_1mhdfre3zczr86mp44jd3xft1g1jg66jwkjtjqixmh6eajfexxti7nxcot9c",
   "restored_count": "1"
 }
 ```
@@ -3101,16 +3147,16 @@ Check whether **wallet** contains **account**
 
 **Request:**
 ```json
-{  
+{
   "action": "wallet_contains",
   "wallet": "000D1BAEC8EC208142C99059B393051BAC8380F9B5A2E6B2489A277D81789F3F",
-  "account": "nano_3e3j5tkog48pnny9dmfzj1r16pg8t1e76dz5tmac6iq689wyjfpi00000000" 
+  "account": "nano_3e3j5tkog48pnny9dmfzj1r16pg8t1e76dz5tmac6iq689wyjfpi00000000"
 }
 ```  
 **Response:**
 ```json
-{  
-  "exists" : "1"
+{
+  "exists": "1"
 }
 ```
 
@@ -3122,14 +3168,14 @@ Creates a new random wallet id
 
 **Request:**
 ```json
-{  
-  "action": "wallet_create" 
+{
+  "action": "wallet_create"
 }
 ```  
 **Response:**
 ```json
-{  
-  "wallet" : "000D1BAEC8EC208142C99059B393051BAC8380F9B5A2E6B2489A277D81789F3F"
+{
+  "wallet": "000D1BAEC8EC208142C99059B393051BAC8380F9B5A2E6B2489A277D81789F3F"
 }
 ```
 **Optional "seed"**
@@ -3145,14 +3191,14 @@ Destroys **wallet** and all contained accounts
 
 **Request:**
 ```json
-{  
-  "action": "wallet_destroy",  
-  "wallet": "000D1BAEC8EC208142C99059B393051BAC8380F9B5A2E6B2489A277D81789F3F"  
+{
+  "action": "wallet_destroy",
+  "wallet": "000D1BAEC8EC208142C99059B393051BAC8380F9B5A2E6B2489A277D81789F3F"
 }
 ```  
 **Response:**
 ```json
-{  
+{
   "destroyed": "1"
 }
 ```
@@ -3164,14 +3210,14 @@ Return a json representation of **wallet**
 
 **Request:**
 ```json
-{  
-  "action": "wallet_export",  
-  "wallet": "000D1BAEC8EC208142C99059B393051BAC8380F9B5A2E6B2489A277D81789F3F"   
+{
+  "action": "wallet_export",
+  "wallet": "000D1BAEC8EC208142C99059B393051BAC8380F9B5A2E6B2489A277D81789F3F"
 }
 ```  
 **Response:**
 ```json
-{  
+{
   "json" : "{\"0000000000000000000000000000000000000000000000000000000000000000\": \"0000000000000000000000000000000000000000000000000000000000000001\"}"
 }
 ```
@@ -3183,17 +3229,17 @@ Returns a list of pairs of account and block hash representing the head block st
 
 **Request:**
 ```json
-{  
+{
   "action": "wallet_frontiers",
-  "wallet": "000D1BAEC8EC208142C99059B393051BAC8380F9B5A2E6B2489A277D81789F3F"    
+  "wallet": "000D1BAEC8EC208142C99059B393051BAC8380F9B5A2E6B2489A277D81789F3F"
 }
 ```  
 **Response:**
 ```json
-{    
-  "frontiers" : {  
-  "nano_3e3j5tkog48pnny9dmfzj1r16pg8t1e76dz5tmac6iq689wyjfpi00000000": "000D1BAEC8EC208142C99059B393051BAC8380F9B5A2E6B2489A277D81789F3F"  
-  }  
+{
+  "frontiers": {
+    "nano_3e3j5tkog48pnny9dmfzj1r16pg8t1e76dz5tmac6iq689wyjfpi00000000": "000D1BAEC8EC208142C99059B393051BAC8380F9B5A2E6B2489A277D81789F3F"
+  }
 }
 ```
 
@@ -3207,32 +3253,33 @@ Reports send/receive information for accounts in wallet. Change blocks are skipp
 
 **Request:**
 ```json
-{  
-  "action": "wallet_history",  
-  "wallet": "000D1BAEC8EC208142C99059B393051BAC8380F9B5A2E6B2489A277D81789F3F"  
+{
+  "action": "wallet_history",
+  "wallet": "000D1BAEC8EC208142C99059B393051BAC8380F9B5A2E6B2489A277D81789F3F"
 }
 ```  
 **Response:**
 ```json
-{  
-  "history":   
-  [  
-    {  
-      "type": "send",   
-      "account": "nano_1qato4k7z3spc8gq1zyd8xeqfbzsoxwo36a45ozbrxcatut7up8ohyardu1z",   
-      "amount": "30000000000000000000000000000000000",   
-      "block_account": "nano_1ipx847tk8o46pwxt5qjdbncjqcbwcc1rrmqnkztrfjy5k7z4imsrata9est"
-      "hash": "87434F8041869A01C8F6F263B87972D7BA443A72E0A97D7A3FD0CCC2358FD6F9"   
-      "local_timestamp": "1527698508"   
-    },  
-      "type": "send",   
-      "account": "nano_38ztgpejb7yrm7rr586nenkn597s3a1sqiy3m3uyqjicht7kzuhnihdk6zpz",   
-      "amount": "40000000000000000000000000000000000",   
-      "block_account": "nano_1ipx847tk8o46pwxt5qjdbncjqcbwcc1rrmqnkztrfjy5k7z4imsrata9est"
-      "hash": "CE898C131AAEE25E05362F247760F8A3ACF34A9796A5AE0D9204E86B0637965E"   
-      "local_timestamp": "1527698492"   
+{
+  "history":
+  [
+    {
+      "type": "send",
+      "account": "nano_1qato4k7z3spc8gq1zyd8xeqfbzsoxwo36a45ozbrxcatut7up8ohyardu1z",
+      "amount": "30000000000000000000000000000000000",
+      "block_account": "nano_1ipx847tk8o46pwxt5qjdbncjqcbwcc1rrmqnkztrfjy5k7z4imsrata9est",
+      "hash": "87434F8041869A01C8F6F263B87972D7BA443A72E0A97D7A3FD0CCC2358FD6F9",
+      "local_timestamp": "1527698508"
+    },
+    {
+      "type": "send",
+      "account": "nano_38ztgpejb7yrm7rr586nenkn597s3a1sqiy3m3uyqjicht7kzuhnihdk6zpz",
+      "amount": "40000000000000000000000000000000000",
+      "block_account": "nano_1ipx847tk8o46pwxt5qjdbncjqcbwcc1rrmqnkztrfjy5k7z4imsrata9est",
+      "hash": "CE898C131AAEE25E05362F247760F8A3ACF34A9796A5AE0D9204E86B0637965E",
+      "local_timestamp": "1527698492"
     }
-  ]  
+  ]
 }
 ```
 **Optional "modified_since"**
@@ -3249,20 +3296,20 @@ Returns the sum of all accounts balances in **wallet**, number of accounts in wa
 
 **Request:**
 ```json
-{  
-  "action": "wallet_info",  
-  "wallet": "000D1BAEC8EC208142C99059B393051BAC8380F9B5A2E6B2489A277D81789F3F"  
+{
+  "action": "wallet_info",
+  "wallet": "000D1BAEC8EC208142C99059B393051BAC8380F9B5A2E6B2489A277D81789F3F"
 }
 ```  
 **Response:**
 ```json
-{  
-  "balance": "10000",   
-  "pending": "10000",   
-  "accounts_count": "3",   
-  "adhoc_count": "1",   
-  "deterministic_count": "2",   
-  "deterministic_index": "2"   
+{
+  "balance": "10000",
+  "pending": "10000",
+  "accounts_count": "3",
+  "adhoc_count": "1",
+  "deterministic_count": "2",
+  "deterministic_index": "2"
 }
 ```
 
@@ -3276,24 +3323,24 @@ Returns frontier, open block, change representative block, balance, last modifie
 
 **Request:**
 ```json
-{  
-  "action": "wallet_ledger",  
-  "wallet": "000D1BAEC8EC208142C99059B393051BAC8380F9B5A2E6B2489A277D81789F3F"   
+{
+  "action": "wallet_ledger",
+  "wallet": "000D1BAEC8EC208142C99059B393051BAC8380F9B5A2E6B2489A277D81789F3F"
 }
 ```  
 **Response:**
 ```json
-{  
-  "accounts": {   
-    "nano_11119gbh8hb4hj1duf7fdtfyf5s75okzxdgupgpgm1bj78ex3kgy7frt3s9n": {   
-      "frontier": "E71AF3E9DD86BBD8B4620EFA63E065B34D358CFC091ACB4E103B965F95783321",   
-      "open_block": "643B77F1ECEFBDBE1CC909872964C1DBBE23A6149BD3CEF2B50B76044659B60F",   
-      "representative_block": "643B77F1ECEFBDBE1CC909872964C1DBBE23A6149BD3CEF2B50B76044659B60F",   
-      "balance": "0",   
-      "modified_timestamp": "1511476234",   
-      "block_count": "2"   
-    }   
-  }   
+{
+  "accounts": {
+    "nano_11119gbh8hb4hj1duf7fdtfyf5s75okzxdgupgpgm1bj78ex3kgy7frt3s9n": {
+      "frontier": "E71AF3E9DD86BBD8B4620EFA63E065B34D358CFC091ACB4E103B965F95783321",
+      "open_block": "643B77F1ECEFBDBE1CC909872964C1DBBE23A6149BD3CEF2B50B76044659B60F",
+      "representative_block": "643B77F1ECEFBDBE1CC909872964C1DBBE23A6149BD3CEF2B50B76044659B60F",
+      "balance": "0",
+      "modified_timestamp": "1511476234",
+      "block_count": "2"
+    }
+  }
 }
 ```  
 **Optional "representative", "weight", "pending"**
@@ -3302,30 +3349,30 @@ Booleans, false by default. Additionally returns representative, voting weight, 
 
 **Request:**
 ```json
-{  
-  "action": "wallet_ledger",  
-  "wallet": "000D1BAEC8EC208142C99059B393051BAC8380F9B5A2E6B2489A277D81789F3F",   
-  "representative": "true",  
-  "weight": "true",  
-  "pending": "true"  
+{
+  "action": "wallet_ledger",
+  "wallet": "000D1BAEC8EC208142C99059B393051BAC8380F9B5A2E6B2489A277D81789F3F",
+  "representative": "true",
+  "weight": "true",
+  "pending": "true"
 }
 ```  
 **Response:**
 ```json
-{  
-  "accounts": {   
-    "nano_11119gbh8hb4hj1duf7fdtfyf5s75okzxdgupgpgm1bj78ex3kgy7frt3s9n": {   
-      "frontier": "E71AF3E9DD86BBD8B4620EFA63E065B34D358CFC091ACB4E103B965F95783321",  
-      "open_block": "643B77F1ECEFBDBE1CC909872964C1DBBE23A6149BD3CEF2B50B76044659B60F",   
-      "representative_block": "643B77F1ECEFBDBE1CC909872964C1DBBE23A6149BD3CEF2B50B76044659B60F",   
-      "balance": "0",   
-      "modified_timestamp": "1511476234",   
-      "block_count": "2",   
-      "representative": "nano_1anrzcuwe64rwxzcco8dkhpyxpi8kd7zsjc1oeimpc3ppca4mrjtwnqposrs",   
-      "weight": "0",   
-      "pending": "0"   
-    }   
-  }   
+{
+  "accounts": {
+    "nano_11119gbh8hb4hj1duf7fdtfyf5s75okzxdgupgpgm1bj78ex3kgy7frt3s9n": {
+      "frontier": "E71AF3E9DD86BBD8B4620EFA63E065B34D358CFC091ACB4E103B965F95783321",
+      "open_block": "643B77F1ECEFBDBE1CC909872964C1DBBE23A6149BD3CEF2B50B76044659B60F",
+      "representative_block": "643B77F1ECEFBDBE1CC909872964C1DBBE23A6149BD3CEF2B50B76044659B60F",
+      "balance": "0",
+      "modified_timestamp": "1511476234",
+      "block_count": "2",
+      "representative": "nano_1anrzcuwe64rwxzcco8dkhpyxpi8kd7zsjc1oeimpc3ppca4mrjtwnqposrs",
+      "weight": "0",
+      "pending": "0"
+    }
+  }
 }
 ```  
 **Optional "modified_since"**
@@ -3340,15 +3387,15 @@ Locks **wallet**
 
 **Request:**
 ```json
-{  
-  "action": "wallet_lock",  
-  "wallet": "000D1BAEC8EC208142C99059B393051BAC8380F9B5A2E6B2489A277D81789F3F"  
+{
+  "action": "wallet_lock",
+  "wallet": "000D1BAEC8EC208142C99059B393051BAC8380F9B5A2E6B2489A277D81789F3F"
 }
 ```  
 **Response:**
 ```json
-{  
-  "locked" : "1"
+{
+  "locked": "1"
 }
 ```
 
@@ -3359,15 +3406,15 @@ Checks whether **wallet** is locked
 
 **Request:**
 ```json
-{  
-  "action": "wallet_locked",  
-  "wallet": "000D1BAEC8EC208142C99059B393051BAC8380F9B5A2E6B2489A277D81789F3F"  
+{
+  "action": "wallet_locked",
+  "wallet": "000D1BAEC8EC208142C99059B393051BAC8380F9B5A2E6B2489A277D81789F3F"
 }
 ```  
 **Response:**
 ```json
-{  
-  "locked" : "0"
+{
+  "locked": "0"
 }
 ```
 
@@ -3379,19 +3426,19 @@ Returns a list of block hashes which have not yet been received by accounts in t
 
 **Request:**
 ```json
-{  
-  "action": "wallet_pending",  
-  "wallet": "000D1BAEC8EC208142C99059B393051BAC8380F9B5A2E6B2489A277D81789F3F"    
+{
+  "action": "wallet_pending",
+  "wallet": "000D1BAEC8EC208142C99059B393051BAC8380F9B5A2E6B2489A277D81789F3F",
   "count": "1"
 }
 ```  
 **Response:**
 ```json
-{  
-  "blocks" : {  
-    "nano_1111111111111111111111111111111111111111111111111117353trpda": ["142A538F36833D1CC78B94E11C766F75818F8B940771335C6C1B8AB880C5BB1D"],  
-    "nano_3t6k35gi95xu6tergt6p69ck76ogmitsa8mnijtpxm9fkcm736xtoncuohr3": ["4C1FEEF0BEA7F50BE35489A1233FE002B212DEA554B55B1B470D78BD8F210C74"]  
-  }  
+{
+  "blocks": {
+    "nano_1111111111111111111111111111111111111111111111111117353trpda": ["142A538F36833D1CC78B94E11C766F75818F8B940771335C6C1B8AB880C5BB1D"],
+    "nano_3t6k35gi95xu6tergt6p69ck76ogmitsa8mnijtpxm9fkcm736xtoncuohr3": ["4C1FEEF0BEA7F50BE35489A1233FE002B212DEA554B55B1B470D78BD8F210C74"]
+  }
 }
 ```  
 **Optional "threshold"**
@@ -3400,23 +3447,23 @@ Number (128 bit, decimal). Returns a list of pending block hashes with amount mo
 
 **Request:**
 ```json
-{  
-  "action": "wallet_pending",  
-  "wallet": "000D1BAEC8EC208142C99059B393051BAC8380F9B5A2E6B2489A277D81789F3F",    
-  "count": "1",  
-  "threshold": "1000000000000000000000000"   
+{
+  "action": "wallet_pending",
+  "wallet": "000D1BAEC8EC208142C99059B393051BAC8380F9B5A2E6B2489A277D81789F3F",
+  "count": "1",
+  "threshold": "1000000000000000000000000"
 }
 ```  
 **Response:**
 ```json
-{  
-  "blocks" : {
-    "nano_1111111111111111111111111111111111111111111111111117353trpda": {    
-        "142A538F36833D1CC78B94E11C766F75818F8B940771335C6C1B8AB880C5BB1D": "6000000000000000000000000000000"    
-    },    
-    "nano_3t6k35gi95xu6tergt6p69ck76ogmitsa8mnijtpxm9fkcm736xtoncuohr3": {    
-        "4C1FEEF0BEA7F50BE35489A1233FE002B212DEA554B55B1B470D78BD8F210C74": "106370018000000000000000000000000"    
-    }  
+{
+  "blocks": {
+    "nano_1111111111111111111111111111111111111111111111111117353trpda": {
+      "142A538F36833D1CC78B94E11C766F75818F8B940771335C6C1B8AB880C5BB1D": "6000000000000000000000000000000"
+    },
+    "nano_3t6k35gi95xu6tergt6p69ck76ogmitsa8mnijtpxm9fkcm736xtoncuohr3": {
+      "4C1FEEF0BEA7F50BE35489A1233FE002B212DEA554B55B1B470D78BD8F210C74": "106370018000000000000000000000000"
+  }
 }
 ```  
 **Optional "source"**
@@ -3426,29 +3473,30 @@ Boolean, false by default. Returns a list of pending block hashes with amount an
 
 **Request:**
 ```json
-{  
-  "action": "wallet_pending",  
-  "wallet": "000D1BAEC8EC208142C99059B393051BAC8380F9B5A2E6B2489A277D81789F3F",    
-  "count": "1",  
-  "source": "true"   
+{
+  "action": "wallet_pending",
+  "wallet": "000D1BAEC8EC208142C99059B393051BAC8380F9B5A2E6B2489A277D81789F3F",
+  "count": "1",
+  "source": "true"
 }
 ```  
 **Response:**
 ```json
-{  
-  "blocks" : {
-    "nano_1111111111111111111111111111111111111111111111111117353trpda": {    
-        "142A538F36833D1CC78B94E11C766F75818F8B940771335C6C1B8AB880C5BB1D": {   
-             "amount": "6000000000000000000000000000000",       
-             "source": "nano_3dcfozsmekr1tr9skf1oa5wbgmxt81qepfdnt7zicq5x3hk65fg4fqj58mbr"
-        }
-    },    
-    "nano_3t6k35gi95xu6tergt6p69ck76ogmitsa8mnijtpxm9fkcm736xtoncuohr3": {    
-        "4C1FEEF0BEA7F50BE35489A1233FE002B212DEA554B55B1B470D78BD8F210C74": {   
-             "amount": "106370018000000000000000000000000",       
-             "source": "nano_13ezf4od79h1tgj9aiu4djzcmmguendtjfuhwfukhuucboua8cpoihmh8byo"
-        }   
-    }  
+{
+  "blocks": {
+    "nano_1111111111111111111111111111111111111111111111111117353trpda": {
+      "142A538F36833D1CC78B94E11C766F75818F8B940771335C6C1B8AB880C5BB1D": {
+        "amount": "6000000000000000000000000000000",
+        "source": "nano_3dcfozsmekr1tr9skf1oa5wbgmxt81qepfdnt7zicq5x3hk65fg4fqj58mbr"
+      }
+    },
+    "nano_3t6k35gi95xu6tergt6p69ck76ogmitsa8mnijtpxm9fkcm736xtoncuohr3": {
+      "4C1FEEF0BEA7F50BE35489A1233FE002B212DEA554B55B1B470D78BD8F210C74": {
+        "amount": "106370018000000000000000000000000",
+        "source": "nano_13ezf4od79h1tgj9aiu4djzcmmguendtjfuhwfukhuucboua8cpoihmh8byo"
+      }
+    }
+  }
 }
 ```  
 **Optional "include_active"**
@@ -3458,11 +3506,11 @@ Boolean, false by default. Include active blocks without finished confirmations
 
 **Request:**
 ```json
-{  
-  "action": "wallet_pending",  
-  "wallet": "000D1BAEC8EC208142C99059B393051BAC8380F9B5A2E6B2489A277D81789F3F",    
-  "count": "1",  
-  "include_active": "true"   
+{
+  "action": "wallet_pending",
+  "wallet": "000D1BAEC8EC208142C99059B393051BAC8380F9B5A2E6B2489A277D81789F3F",
+  "count": "1",
+  "include_active": "true"
 }
 ```  
 
@@ -3478,15 +3526,15 @@ Returns the default representative for **wallet**
 
 **Request:**
 ```json
-{  
-  "action": "wallet_representative",  
+{
+  "action": "wallet_representative",
   "wallet": "000D1BAEC8EC208142C99059B393051BAC8380F9B5A2E6B2489A277D81789F3F"
 }
 ```  
 **Response:**
 ```json
-{  
-  "representative" : "nano_3e3j5tkog48pnny9dmfzj1r16pg8t1e76dz5tmac6iq689wyjfpi00000000"
+{
+  "representative": "nano_3e3j5tkog48pnny9dmfzj1r16pg8t1e76dz5tmac6iq689wyjfpi00000000"
 }
 ```
 
@@ -3498,15 +3546,15 @@ Sets the default **representative** for **wallet** _(used only for new accounts,
 
 **Request:**
 ```json
-{  
-  "action": "wallet_representative_set",  
+{
+  "action": "wallet_representative_set",
   "wallet": "000D1BAEC8EC208142C99059B393051BAC8380F9B5A2E6B2489A277D81789F3F",
   "representative": "nano_3e3j5tkog48pnny9dmfzj1r16pg8t1e76dz5tmac6iq689wyjfpi00000000"
 }
 ```  
 **Response:**
 ```json
-{  
+{
   "set": "1"
 }
 ```
@@ -3524,19 +3572,19 @@ Rebroadcast blocks for accounts from **wallet** starting at frontier down to **c
 
 **Request:**
 ```json
-{  
-  "action": "wallet_republish",    
+{
+  "action": "wallet_republish",
   "wallet": "000D1BAEC8EC208142C99059B393051BAC8380F9B5A2E6B2489A277D81789F3F",
-  "count": "2"   
+  "count": "2"
 }
 ```  
 **Response:**
 ```json
-{    
-  "blocks": [   
-      "991CF190094C00F0B68E2E5F75F6BEE95A2E0BD93CEAA4A6734DB9F19B728948",   
-      "A170D51B94E00371ACE76E35AC81DC9405D5D04D4CEBC399AEACE07AE05DD293",   
-      "90D0C16AC92DD35814E84BFBCC739A039615D0A42A76EF44ADAEF1D99E9F8A35"   
+{
+  "blocks": [
+    "991CF190094C00F0B68E2E5F75F6BEE95A2E0BD93CEAA4A6734DB9F19B728948",
+    "A170D51B94E00371ACE76E35AC81DC9405D5D04D4CEBC399AEACE07AE05DD293",
+    "90D0C16AC92DD35814E84BFBCC739A039615D0A42A76EF44ADAEF1D99E9F8A35"
   ]       
 }
 ```   
@@ -3549,17 +3597,17 @@ Returns a list of pairs of account and work from **wallet**
 
 **Request:**
 ```json
-{  
-    "action": "wallet_work_get",  
-    "wallet": "000D1BAEC8EC208142C99059B393051BAC8380F9B5A2E6B2489A277D81789F3F"  
+{
+  "action": "wallet_work_get",
+  "wallet": "000D1BAEC8EC208142C99059B393051BAC8380F9B5A2E6B2489A277D81789F3F"
 }
 ```  
 **Response:**
 ```json
-{  
-   "works": {
-       "nano_1111111111111111111111111111111111111111111111111111hifc8npp": "432e5cf728c90f4f"   
-   }
+{
+  "works": {
+    "nano_1111111111111111111111111111111111111111111111111111hifc8npp": "432e5cf728c90f4f"
+  }
 }
 ```  
 
@@ -3571,16 +3619,16 @@ Retrieves work for **account** in **wallet**
 
 **Request:**
 ```json
-{  
-    "action": "work_get",  
-    "wallet": "000D1BAEC8EC208142C99059B393051BAC8380F9B5A2E6B2489A277D81789F3F",   
-    "account": "nano_1111111111111111111111111111111111111111111111111111hifc8npp"  
+{
+  "action": "work_get",
+  "wallet": "000D1BAEC8EC208142C99059B393051BAC8380F9B5A2E6B2489A277D81789F3F",
+  "account": "nano_1111111111111111111111111111111111111111111111111111hifc8npp"
 }
 ```  
 **Response:**
 ```json
-{  
-    "work": "432e5cf728c90f4f"  
+{
+  "work": "432e5cf728c90f4f"
 }
 ```  
 
@@ -3592,17 +3640,17 @@ Set **work** for **account** in **wallet**
 
 **Request:**
 ```json
-{  
-    "action": "work_set",  
-    "wallet": "000D1BAEC8EC208142C99059B393051BAC8380F9B5A2E6B2489A277D81789F3F",   
-    "account": "nano_1111111111111111111111111111111111111111111111111111hifc8npp",  
-    "work": "0000000000000000"  
+{
+  "action": "work_set",
+  "wallet": "000D1BAEC8EC208142C99059B393051BAC8380F9B5A2E6B2489A277D81789F3F",
+  "account": "nano_1111111111111111111111111111111111111111111111111111hifc8npp",
+  "work": "0000000000000000"
 }
 ```  
 **Response:**
 ```json
-{  
-    "success": ""  
+{
+    "success": ""
 }
 ```  
 
@@ -3617,15 +3665,15 @@ Divide a raw amount down by the krai ratio.
 
 **Request:**
 ```json
-{  
-  "action": "krai_from_raw",  
+{
+  "action": "krai_from_raw",
   "amount": "1000000000000000000000000000"
 }
 ```  
 **Response:**
 ```json
-{  
-  "amount": "1"  
+{
+  "amount": "1"
 }
 ```
 
@@ -3636,15 +3684,15 @@ Multiply an krai amount by the krai ratio.
 
 **Request:**
 ```json
-{  
-  "action": "krai_to_raw",  
+{
+  "action": "krai_to_raw",
   "amount": "1"
 }
 ```  
 **Response:**
 ```json
-{  
-  "amount": "1000000000000000000000000000"  
+{
+  "amount": "1000000000000000000000000000"
 }
 ```
 
@@ -3655,15 +3703,15 @@ Divide a raw amount down by the Mrai ratio.
 
 **Request:**
 ```json
-{  
-  "action": "mrai_from_raw",  
+{
+  "action": "mrai_from_raw",
   "amount": "1000000000000000000000000000000"
 }
 ```  
 **Response:**
 ```json
-{  
-  "amount": "1"  
+{
+  "amount": "1"
 }
 ```
 
@@ -3674,15 +3722,15 @@ Multiply an Mrai amount by the Mrai ratio.
 
 **Request:**
 ```json
-{  
-  "action": "mrai_to_raw",  
+{
+  "action": "mrai_to_raw",
   "amount": "1"
 }
 ```  
 **Response:**
 ```json
-{  
-  "amount": "1000000000000000000000000000000"  
+{
+  "amount": "1000000000000000000000000000000"
 }
 ```
 
@@ -3693,15 +3741,15 @@ Divide a raw amount down by the rai ratio.
 
 **Request:**
 ```json
-{  
-  "action": "rai_from_raw",  
+{
+  "action": "rai_from_raw",
   "amount": "1000000000000000000000000"
 }
 ```  
 **Response:**
 ```json
-{  
-  "amount": "1"  
+{
+  "amount": "1"
 }
 ```
 
@@ -3712,15 +3760,15 @@ Multiply an rai amount by the rai ratio.
 
 **Request:**
 ```json
-{  
-  "action": "rai_to_raw",  
+{
+  "action": "rai_to_raw",
   "amount": "1"
 }
 ```  
 **Response:**
 ```json
-{  
-  "amount": "1000000000000000000000000"  
+{
+  "amount": "1000000000000000000000000"
 }
 ```
 
@@ -3742,15 +3790,15 @@ Begin a new payment session. Searches wallet for an account that's marked as ava
 
 **Request:**
 ```json
-{  
-"action": "payment_begin",  
-"wallet": "000D1BAEC8EC208142C99059B393051BAC8380F9B5A2E6B2489A277D81789F3F"  
+{
+  "action": "payment_begin",
+  "wallet": "000D1BAEC8EC208142C99059B393051BAC8380F9B5A2E6B2489A277D81789F3F"
 }
 ```  
 **Response:**
 ```json
-{  
-"account" : "nano_3e3j5tkog48pnny9dmfzj1r16pg8t1e76dz5tmac6iq689wyjfpi00000000"  
+{
+  "account" : "nano_3e3j5tkog48pnny9dmfzj1r16pg8t1e76dz5tmac6iq689wyjfpi00000000"
 }
 ```  
 
@@ -3762,15 +3810,16 @@ End a payment session.  Marks the account as available for use in a payment sess
 
 **Request:**
 ```json
-{  
-  "action": "payment_end",  
-  "account": "nano_3e3j5tkog48pnny9dmfzj1r16pg8t1e76dz5tmac6iq689wyjfpi00000000",  
-  "wallet": "FFFD1BAEC8EC20814BBB9059B393051AAA8380F9B5A2E6B2489A277D81789EEE"  
+{
+  "action": "payment_end",
+  "account": "nano_3e3j5tkog48pnny9dmfzj1r16pg8t1e76dz5tmac6iq689wyjfpi00000000",
+  "wallet": "FFFD1BAEC8EC20814BBB9059B393051AAA8380F9B5A2E6B2489A277D81789EEE"
 }
 ```  
 **Response:**
 ```json
-{}
+{
+}
 ```   
 
 ---
@@ -3781,15 +3830,15 @@ Marks all accounts in wallet as available for being used as a payment session.
 
 **Request:**
 ```json
-{  
-  "action": "payment_init",  
-  "wallet": "000D1BAEC8EC208142C99059B393051BAC8380F9B5A2E6B2489A277D81789F3F"  
+{
+  "action": "payment_init",
+  "wallet": "000D1BAEC8EC208142C99059B393051BAC8380F9B5A2E6B2489A277D81789F3F"
 }
 ```  
 **Response:**
 ```json
-{  
-  "status" : "Ready"  
+{
+  "status": "Ready"
 }
 ```  
 
@@ -3801,16 +3850,16 @@ Wait for payment of 'amount' to arrive in 'account' or until 'timeout' milliseco
 
 **Request:**
 ```json
-{  
-  "action": "payment_wait",  
-  "account": "nano_3e3j5tkog48pnny9dmfzj1r16pg8t1e76dz5tmac6iq689wyjfpi00000000",  
-  "amount": "1",  
-  "timeout": "1000"  
+{
+  "action": "payment_wait",
+  "account": "nano_3e3j5tkog48pnny9dmfzj1r16pg8t1e76dz5tmac6iq689wyjfpi00000000",
+  "amount": "1",
+  "timeout": "1000"
 }
 ```  
 **Response:**
 ```json
-{  
-  "status" : "success"  
+{
+  "status" : "success"
 }
 ```  

--- a/docs/commands/rpc-protocol.md
+++ b/docs/commands/rpc-protocol.md
@@ -2345,7 +2345,7 @@ Default "false". If "true", "contents" will contain a JSON subtree instead of a 
 
 ### unchecked_keys   
 _version 8.0+_   
-Retrieves unchecked database keys, blocks hashes & a json representations of unchecked pending blocks starting from **key** up to **count**.Using the optional `json_block` is recommended since v19.0.   
+Retrieves unchecked database keys, blocks hashes & a json representations of unchecked pending blocks starting from **key** up to **count**. Using the optional `json_block` is recommended since v19.0.   
 
 **Request:**
 ```json

--- a/docs/integration-guides/key-management.md
+++ b/docs/integration-guides/key-management.md
@@ -227,11 +227,11 @@ curl -d '{
     When not following this guide closely, the following **inappropriate sequence of events could lead to erroneous amounts sent** to a recipient.
 
     1. An account's balance, say 5 $nano$, was obtained using the [`account_balance`](/commands/rpc-protocol#account_balance) RPC command (**never use this command for transaction related operations**). This balance is valid as of hypothetical **BLOCK_A**.
-    2. By another process you control, a receive (**BLOCK_B**) was signed and broadcasted into your account-chain (race-condition).
+    1. By another process you control, a receive (**BLOCK_B**) was signed and broadcasted into your account-chain (race-condition).
     * Lets say this `receive` increased the funds on the account chain by 10 $nano$, resulting in a final balance 15 $nano$.
-    3. The account's frontier block is obtained by the [`accounts_frontiers`](/commands/rpc-protocol#accounts_frontiers) RPC command, returning the hash of **BLOCK_B**. Other transaction metadata is obtained by other RPC commands.
-    4. With the collected data, if a send transaction was created for 3 $nano$, the final balance would be computed as $5 - 3$, or 2 $nano$.
-    5. When this is broadcasted, since it is referring to the current head block on the account, **BLOCK_B**, the network would accept it. But, because the balance as of **BLOCK_B** was actually 15 $nano$, this would result in 12 $nano$ being sent to the recipient.
+    1. The account's frontier block is obtained by the [`accounts_frontiers`](/commands/rpc-protocol#accounts_frontiers) RPC command, returning the hash of **BLOCK_B**. Other transaction metadata is obtained by other RPC commands.
+    1. With the collected data, if a send transaction was created for 3 $nano$, the final balance would be computed as $5 - 3$, or 2 $nano$.
+    1. When this is broadcasted, since it is referring to the current head block on the account, **BLOCK_B**, the network would accept it. But, because the balance as of **BLOCK_B** was actually 15 $nano$, this would result in 12 $nano$ being sent to the recipient.
 
     For this reason, **only populate transaction data source from a single [`account_info`](/commands/rpc-protocol#account_info) RPC call**.
 
@@ -541,8 +541,8 @@ Prv: 1F6FEB5D1E05C10B904E1112F430C3FA93ACC7067206B63AD155199501794E3E
     The nano\_node responds with three pieces of information:
     
     1. The seed of the wallet (back this up).
-    2. The pairing public address
-    3. The private key (deterministically derived from seed) of accounts within the wallet.
+    1. The pairing public address
+    1. The private key (deterministically derived from seed) of accounts within the wallet.
 
     Additional notes:
 

--- a/docs/integration-guides/key-management.md
+++ b/docs/integration-guides/key-management.md
@@ -371,7 +371,7 @@ curl -d '{
     | Field              | Value |
     |                    |       |
     | `"type"`           | always the constant `"state"` |
-    | `"previous"`       | `"frontier"` from `account_info` response |
+    | `"previous"`       | always the constant "0" as this request is for the first block of the account |
     | `"account"`        | `"account"` address used in the `account_info` call above that the block will be created for |
     | `"representative"` | `"representative"` the account address to use as [representative](/integration-guides/the-basics#representatives) for your account. Choose a reliable, trustworthy representative. |
     | `"balance"`        | balance of the account in $raw$ **after** this transaction is completed. In this example, we will receive $100\ raw$, based on the assumed details from the `"pending"` response above. |

--- a/docs/integration-guides/key-management.md
+++ b/docs/integration-guides/key-management.md
@@ -227,11 +227,11 @@ curl -d '{
     When not following this guide closely, the following **inappropriate sequence of events could lead to erroneous amounts sent** to a recipient.
 
     1. An account's balance, say 5 $nano$, was obtained using the [`account_balance`](/commands/rpc-protocol#account_balance) RPC command (**never use this command for transaction related operations**). This balance is valid as of hypothetical **BLOCK_A**.
-    1. By another process you control, a receive (**BLOCK_B**) was signed and broadcasted into your account-chain (race-condition).
+    2. By another process you control, a receive (**BLOCK_B**) was signed and broadcasted into your account-chain (race-condition).
     * Lets say this `receive` increased the funds on the account chain by 10 $nano$, resulting in a final balance 15 $nano$.
-    1. The account's frontier block is obtained by the [`accounts_frontiers`](/commands/rpc-protocol#accounts_frontiers) RPC command, returning the hash of **BLOCK_B**. Other transaction metadata is obtained by other RPC commands.
-    1. With the collected data, if a send transaction was created for 3 $nano$, the final balance would be computed as $5 - 3$, or 2 $nano$.
-    1. When this is broadcasted, since it is referring to the current head block on the account, **BLOCK_B**, the network would accept it. But, because the balance as of **BLOCK_B** was actually 15 $nano$, this would result in 12 $nano$ being sent to the recipient.
+    3. The account's frontier block is obtained by the [`accounts_frontiers`](/commands/rpc-protocol#accounts_frontiers) RPC command, returning the hash of **BLOCK_B**. Other transaction metadata is obtained by other RPC commands.
+    4. With the collected data, if a send transaction was created for 3 $nano$, the final balance would be computed as $5 - 3$, or 2 $nano$.
+    5. When this is broadcasted, since it is referring to the current head block on the account, **BLOCK_B**, the network would accept it. But, because the balance as of **BLOCK_B** was actually 15 $nano$, this would result in 12 $nano$ being sent to the recipient.
 
     For this reason, **only populate transaction data source from a single [`account_info`](/commands/rpc-protocol#account_info) RPC call**.
 
@@ -541,8 +541,8 @@ Prv: 1F6FEB5D1E05C10B904E1112F430C3FA93ACC7067206B63AD155199501794E3E
     The nano\_node responds with three pieces of information:
     
     1. The seed of the wallet (back this up).
-    1. The pairing public address
-    1. The private key (deterministically derived from seed) of accounts within the wallet.
+    2. The pairing public address
+    3. The private key (deterministically derived from seed) of accounts within the wallet.
 
     Additional notes:
 

--- a/docs/integration-guides/key-management.md
+++ b/docs/integration-guides/key-management.md
@@ -335,7 +335,7 @@ curl -d '{
 
 #### First Receive Transaction
 
-The first transaction of every account is crafted in a slightly different way. To open an account, you must have sent some funds to it with a [Send Transaction](#send-transaction) from another account. The funds will be **pending** on the receiving account. If you already know the hash of the pending transaction, you can skip Step 1.
+The first transaction of an account is crafted in a slightly different way. To open an account, you must have sent some funds to it with a [Send Transaction](#send-transaction) from another account. The funds will be **pending** on the receiving account. If you already know the hash of the pending transaction, you can skip Step 1.
 
 !!! example "Step 1: Obtain the pending transaction block hash"
 

--- a/docs/integration-guides/key-management.md
+++ b/docs/integration-guides/key-management.md
@@ -169,6 +169,7 @@ curl -d '{
 
     | Field              | Value |
     |                    |       |
+    | `"json_block"`     | always `"true"`, so that the output is JSON-formatted |
     | `"type"`           | always the constant `"state"` |
     | `"previous"`       | `"frontier"` from `account_info` response |
     | `"account"`        | `"account"` address used in the `account_info` call above that the block will be created for |
@@ -182,6 +183,7 @@ curl -d '{
 ```bash
 curl -d '{
   "action": "block_create",
+  "json_block": "true",
   "type": "state",
   "previous": "92BA74A7D6DC7557F3EDA95ADC6341D51AC777A0A6FF0688A5C492AB2B2CB40D",
   "account": "nano_1e5aqegc1jb7qe964u4adzmcezyo6o146zb8hm6dft8tkp79za3sxwjym5rx",
@@ -197,24 +199,23 @@ curl -d '{
 ```json
 {
   "hash": "8DB5C07E0E62E9DFE8558CB9BD654A115B02245B38CD369753CECE36DAD13C05",
-  "block": "{\n
-      \"type\": \"state\",\n
-      \"account\": \"nano_1e5aqegc1jb7qe964u4adzmcezyo6o146zb8hm6dft8tkp79za3sxwjym5rx\",\n
-      \"previous\": \"92BA74A7D6DC7557F3EDA95ADC6341D51AC777A0A6FF0688A5C492AB2B2CB40D\",\n
-      \"representative\": \"nano_1stofnrxuz3cai7ze75o174bpm7scwj9jn3nxsn8ntzg784jf1gzn1jjdkou\",\n
-      \"balance\": \"3618869000000000000000000000000\",\n
-      \"link\": \"5C2FBB148E006A8E8BA7A75DD86C9FE00C83F5FFDBFD76EAA09531071436B6AF\",\n
-      \"link_as_account\": \"nano_1q3hqecaw15cjt7thbtxu3pbzr1eihtzzpzxguoc37bj1wc5ffoh7w74gi6p\",\n
-      \"signature\": \"79240D56231EF1885F354473733AF158DC6DA50E53836179565A20C0BE89D473ED3FF8CD11545FF0ED162A0B2C4626FD6BF84518568F8BB965A4884C7C32C205\",\n
-      \"work\": \"fbffed7c73b61367\"\n
-    }\n"
+  "block": {
+    "type": "state",
+    "account": "nano_1e5aqegc1jb7qe964u4adzmcezyo6o146zb8hm6dft8tkp79za3sxwjym5rx",
+    "previous": "92BA74A7D6DC7557F3EDA95ADC6341D51AC777A0A6FF0688A5C492AB2B2CB40D",
+    "representative": "nano_1stofnrxuz3cai7ze75o174bpm7scwj9jn3nxsn8ntzg784jf1gzn1jjdkou",
+    "balance": "3618869000000000000000000000000",
+    "link": "5C2FBB148E006A8E8BA7A75DD86C9FE00C83F5FFDBFD76EAA09531071436B6AF",
+    "link_as_account": "nano_1q3hqecaw15cjt7thbtxu3pbzr1eihtzzpzxguoc37bj1wc5ffoh7w74gi6p",
+    "signature": "79240D56231EF1885F354473733AF158DC6DA50E53836179565A20C0BE89D473ED3FF8CD11545FF0ED162A0B2C4626FD6BF84518568F8BB965A4884C7C32C205",
+    "work": "fbffed7c73b61367"
+  }
 }
 ```
 
 !!! info "Additional details"
-    * The newlines (`"\n"`) in the response are for display purposes only and are ignored.
-    * Always ensure that every quotation mark is properly escaped.
-    * [`block_create`](/commands/rpc-protocol#block_create) RPC commands generally take longer than other RPC commands because the nano\_node has to generate the [Proof-of-Work](/integration-guides/the-basics/#proof-of-work) for the transaction. The response block data is already properly escaped for the [`process`](/commands/rpc-protocol#process) RPC command.
+    * The option `json_block`, available since V19.0, makes the RPC call return a non-stringified version of the block, which is easier to parse and always recommended.
+    * [`block_create`](/commands/rpc-protocol#block_create) RPC commands generally take longer than other RPC commands because the nano\_node has to generate the [Proof-of-Work](/integration-guides/the-basics/#proof-of-work) for the transaction. The response block data is already properly formatted to include in the [`process`](/commands/rpc-protocol#process) RPC command.
     * The nano\_node creating and signing this transaction has no concept of what the transaction amount is, nor network state; all the nano\_node knows is that it is creating a block whose previous block on the account chain has hash `92BA74A7D6DC7557F3EDA95ADC6341D51AC777A0A6FF0688A5C492AB2B2CB40D` results in the account having a balance of `3618869000000000000000000000000`.
     * If the account's balance at block hash `92BA74A7D6DC7557F3EDA95ADC6341D51AC777A0A6FF0688A5C492AB2B2CB40D` was actually `5618869000000000000000000000000`, then 2 $nano$ would have been sent to `nano_1q3hqecaw15cjt7thbtxu3pbzr1eihtzzpzxguoc37bj1wc5ffoh7w74gi6p`.
 
@@ -276,6 +277,7 @@ curl -d '{
 
     | Field              | Value |
     |                    |       |
+    | `"json_block"`     | always `"true"`, so that the output is JSON-formatted |
     | `"type"`           | always the constant `"state"` |
     | `"previous"`       | `"frontier"` from `account_info` response |
     | `"account"`        | `"account"` address used in the `account_info` call above that the block will be created for |
@@ -289,6 +291,7 @@ curl -d '{
 ```bash
 curl -d '{
   "action": "block_create",
+  "json_block": "true",
   "type": "state",
   "previous": "92BA74A7D6DC7557F3EDA95ADC6341D51AC777A0A6FF0688A5C492AB2B2CB40D",
   "account": "nano_1e5aqegc1jb7qe964u4adzmcezyo6o146zb8hm6dft8tkp79za3sxwjym5rx",
@@ -304,17 +307,17 @@ curl -d '{
 ```json
 {
   "hash": "350D145570578A36D3D5ADE58DC7465F4CAAF257DD55BD93055FF826057E2CDD",
-  "block": "{\n
-      \"type\": \"state\",\n
-      \"account\": \"nano_1e5aqegc1jb7qe964u4adzmcezyo6o146zb8hm6dft8tkp79za3sxwjym5rx\",\n
-      \"previous\": \"92BA74A7D6DC7557F3EDA95ADC6341D51AC777A0A6FF0688A5C492AB2B2CB40D\",\n
-      \"representative\": \"nano_1stofnrxuz3cai7ze75o174bpm7scwj9jn3nxsn8ntzg784jf1gzn1jjdkou\",\n
-      \"balance\": \"11618869000000000000000000000000\",\n
-      \"link\": \"CBC911F57B6827649423C92C88C0C56637A4274FF019E77E24D61D12B5338783\",\n
-      \"link_as_account\": \"nano_3kyb49tqpt39ekc49kbej51ecsjqnimnzw1swxz4boix4ctm93w517umuiw8\",\n
-      \"signature\": \"EEFFE1EFCCC8F2F6F2F1B79B80ABE855939DD9D6341323186494ADEE775DAADB3B6A6A07A85511F2185F6E739C4A54F1454436E22255A542ED879FD04FEED001\",\n
-      \"work\": \"c5cf86de24b24419\"\n
-    }\n"
+  "block": {
+    "type": "state",
+    "account": "nano_1e5aqegc1jb7qe964u4adzmcezyo6o146zb8hm6dft8tkp79za3sxwjym5rx",
+    "previous": "92BA74A7D6DC7557F3EDA95ADC6341D51AC777A0A6FF0688A5C492AB2B2CB40D",
+    "representative": "nano_1stofnrxuz3cai7ze75o174bpm7scwj9jn3nxsn8ntzg784jf1gzn1jjdkou",
+    "balance": "11618869000000000000000000000000",
+    "link": "CBC911F57B6827649423C92C88C0C56637A4274FF019E77E24D61D12B5338783",
+    "link_as_account": "nano_3kyb49tqpt39ekc49kbej51ecsjqnimnzw1swxz4boix4ctm93w517umuiw8",
+    "signature": "EEFFE1EFCCC8F2F6F2F1B79B80ABE855939DD9D6341323186494ADEE775DAADB3B6A6A07A85511F2185F6E739C4A54F1454436E22255A542ED879FD04FEED001",
+    "work": "c5cf86de24b24419"
+  }
 }
 ```
 
@@ -370,6 +373,7 @@ curl -d '{
 
     | Field              | Value |
     |                    |       |
+    | `"json_block"`     | always `"true"`, so that the output is JSON-formatted |
     | `"type"`           | always the constant `"state"` |
     | `"previous"`       | always the constant "0" as this request is for the first block of the account |
     | `"account"`        | `"account"` address used in the `account_info` call above that the block will be created for |
@@ -383,6 +387,7 @@ curl -d '{
 ```bash
 curl -d '{
   "action": "block_create",
+  "json_block": "true",
   "type": "state",
   "previous": "0",
   "account": "nano_1rawdji18mmcu9psd6h87qath4ta7iqfy8i4rqi89sfdwtbcxn57jm9k3q11",
@@ -398,17 +403,17 @@ curl -d '{
 ```json
 {
   "hash": "ED3BE5340CC9D62964B5A5F84375A06078CBEDC45FB5FA2926985D6E27D803BB",
-  "block": "{\n
-    \"type\": \"state\",\n
-    \"account\": \"nano_1rawdji18mmcu9psd6h87qath4ta7iqfy8i4rqi89sfdwtbcxn57jm9k3q11\",\n
-    \"previous\": \"0000000000000000000000000000000000000000000000000000000000000000\",\n
-    \"representative\": \"nano_1stofnrxuz3cai7ze75o174bpm7scwj9jn3nxsn8ntzg784jf1gzn1jjdkou\",\n
-    \"balance\": \"100\",\n
-    \"link\": \"5B2DA492506339C0459867AA1DA1E7EDAAC4344342FAB0848F43B46D248C8E99\",\n
-    \"link_as_account\": \"nano_1psfnkb71rssr34sisxc5piyhufcrit68iqtp44ayixnfnkas5nsiuy58za7\",\n
-    \"signature\": \"903991714A55954D15C91DB75CAE2FBF1DD1A2D6DA5524AA2870F76B50A8FE8B4E3FBB53E46B9E82638104AAB3CFA71CFC36B7D676B3D6CAE84725D04E4C360F\",\n
-    \"work\": \"08d09dc3405d9441\"\n
-  }\n"
+  "block": {
+    "type": "state",
+    "account": "nano_1rawdji18mmcu9psd6h87qath4ta7iqfy8i4rqi89sfdwtbcxn57jm9k3q11",
+    "previous": "0000000000000000000000000000000000000000000000000000000000000000",
+    "representative": "nano_1stofnrxuz3cai7ze75o174bpm7scwj9jn3nxsn8ntzg784jf1gzn1jjdkou",
+    "balance": "100",
+    "link": "5B2DA492506339C0459867AA1DA1E7EDAAC4344342FAB0848F43B46D248C8E99",
+    "link_as_account": "nano_1psfnkb71rssr34sisxc5piyhufcrit68iqtp44ayixnfnkas5nsiuy58za7",
+    "signature": "903991714A55954D15C91DB75CAE2FBF1DD1A2D6DA5524AA2870F76B50A8FE8B4E3FBB53E46B9E82638104AAB3CFA71CFC36B7D676B3D6CAE84725D04E4C360F",
+    "work": "08d09dc3405d9441"
+  }
 }
 ```
 
@@ -420,23 +425,26 @@ curl -d '{
 ### Broadcasting Transactions
 
 !!! example "Broadcast using [`process`](/commands/rpc-protocol/#process) RPC command"
-    Common to all of these transactions is the need to broadcast the completed block to the network. This is achieved by the [`process`](/commands/rpc-protocol#process) RPC command which accepts the block as stringified JSON data. A successful broadcast will return the broadcasted block's hash.
+    Common to all of these transactions is the need to broadcast the completed block to the network. This is achieved by the [`process`](/commands/rpc-protocol#process) RPC command which accepts the block as stringified JSON data. If you followed the previous examples, you used the option `json_block` for RPC [`block_create`](/commands/rpc-protocol#block_create), which allows you use the non-stringified version, as long as you include the same option in this RPC call.  
+    A successful broadcast will return the broadcasted block's hash.
 
 ##### Request Example
 ```bash
 curl -d '{
   "action": "process",
-  "block": "{
-      \"type\": \"state\",
-      \"account\": \"nano_1e5aqegc1jb7qe964u4adzmcezyo6o146zb8hm6dft8tkp79za3sxwjym5rx\",
-      \"previous\": \"92BA74A7D6DC7557F3EDA95ADC6341D51AC777A0A6FF0688A5C492AB2B2CB40D\",
-      \"representative\": \"nano_1stofnrxuz3cai7ze75o174bpm7scwj9jn3nxsn8ntzg784jf1gzn1jjdkou\",
-      \"balance\": \"11618869000000000000000000000000\",
-      \"link\": \"CBC911F57B6827649423C92C88C0C56637A4274FF019E77E24D61D12B5338783\",
-      \"signature\": \"EEFFE1EFCCC8F2F6F2F1B79B80ABE855939DD9D6341323186494ADEE775DAADB3B6A6A07A85511F2185F6E739C4A54F1454436E22255A542ED879FD04FEED001\",
-      \"work\": \"c5cf86de24b24419\"
-    }"
-  }' http://127.0.0.1:7076
+  "json_block": "true",
+  "block": {
+    "type": "state",
+    "account": "nano_1rawdji18mmcu9psd6h87qath4ta7iqfy8i4rqi89sfdwtbcxn57jm9k3q11",
+    "previous": "0000000000000000000000000000000000000000000000000000000000000000",
+    "representative": "nano_1stofnrxuz3cai7ze75o174bpm7scwj9jn3nxsn8ntzg784jf1gzn1jjdkou",
+    "balance": "100",
+    "link": "5B2DA492506339C0459867AA1DA1E7EDAAC4344342FAB0848F43B46D248C8E99",
+    "link_as_account": "nano_1psfnkb71rssr34sisxc5piyhufcrit68iqtp44ayixnfnkas5nsiuy58za7",
+    "signature": "903991714A55954D15C91DB75CAE2FBF1DD1A2D6DA5524AA2870F76B50A8FE8B4E3FBB53E46B9E82638104AAB3CFA71CFC36B7D676B3D6CAE84725D04E4C360F",
+    "work": "08d09dc3405d9441"
+  }
+}' http://127.0.0.1:7076
 ```
 
 ##### Success Response

--- a/docs/integration-guides/key-management.md
+++ b/docs/integration-guides/key-management.md
@@ -373,7 +373,7 @@ curl -d '{
     | `"type"`           | always the constant `"state"` |
     | `"previous"`       | `"frontier"` from `account_info` response |
     | `"account"`        | `"account"` address used in the `account_info` call above that the block will be created for |
-    | `"representative"` | `"representative"` the account address to use as representative for your account. Choose a reliable, trustworthy representative. |
+    | `"representative"` | `"representative"` the account address to use as [representative](/integration-guides/the-basics#representatives) for your account. Choose a reliable, trustworthy representative. |
     | `"balance"`        | balance of the account in $raw$ **after** this transaction is completed. In this example, we will receive $100\ raw$, based on the assumed details from the `"pending"` response above. |
     | `"link"`           | block hash of its paired send transaction, in this case assumed to be the block `5B2DA492506339C0459867AA1DA1E7EDAAC4344342FAB0848F43B46D248C8E99` |
     | `"key"`            | account's private key |

--- a/docs/integration-guides/the-basics.md
+++ b/docs/integration-guides/the-basics.md
@@ -248,11 +248,12 @@ Read these examples in order to correctly interpret balances and block hashes on
 
 * Create a block to receive Nano for account: `nano_3igf8hd4sjshoibbbkeitmgkp1o6ug4xads43j6e4gqkj5xk5o83j8ja9php` account-chain.
 * Sets `nano_3p1asma84n8k84joneka776q4egm5wwru3suho9wjsfyuem8j95b3c78nw8j` as the representative.
-* This receives the block hash `B2EC73C1F503F47E051AD72ECB512C63BA8E1A0ACC2CEE4EA9A22FE1CBDB693F` and because this is the first block on the account, it is considered "opened".
+* This receives the block hash `B2EC73C1F503F47E051AD72ECB512C63BA8E1A0ACC2CEE4EA9A22FE1CBDB693F` and because this is the first block on the account, the account is considered "opened".
 
 ```bash
 curl -d '{
   "action":"block_create",
+  "json_block": "true",
   "type":"state",
   "previous":"FC5A7FB777110A858052468D448B2DF22B648943C097C0608D1E2341007438B0",
   "account":"nano_3igf8hd4sjshoibbbkeitmgkp1o6ug4xads43j6e4gqkj5xk5o83j8ja9php",
@@ -266,17 +267,17 @@ curl -d '{
 ```json
 {
   "hash": "597395E83BD04DF8EF30AF04234EAAFE0606A883CF4AEAD2DB8196AAF5C4444F",
-  "block": "{\n
-    \"type\": \"state\",\n
-    \"account\": \"nano_3igf8hd4sjshoibbbkeitmgkp1o6ug4xads43j6e4gqkj5xk5o83j8ja9php\",\n
-    \"previous\": \"FC5A7FB777110A858052468D448B2DF22B648943C097C0608D1E2341007438B0\",\n
-    \"representative\": \"nano_3p1asma84n8k84joneka776q4egm5wwru3suho9wjsfyuem8j95b3c78nw8j\",\n
-    \"balance\": \"5000000000000000000000000000001\",\n
-    \"link\": \"B2EC73C1F503F47E051AD72ECB512C63BA8E1A0ACC2CEE4EA9A22FE1CBDB693F\",\n
-    \"link_as_account\": \"nano_3eqegh1zc1znhr4joosgsfakrrxtjrf1om3exs9cmajhw97xptbzi3kfba1j\",\n
-    \"signature\": \"90CBD62F5466E35DB3BFE5EFDBC6283BD30C0591A3787C9458D11F2AF6188E45E6E71B5F4A8E3598B1C80080D6024867878E355161AD1935CD757477991D3B0B\",\n
-    \"work\": \"0000000000000000\"\n
-  }\n"
+  "block": {
+    "type": "state",
+    "account": "nano_3igf8hd4sjshoibbbkeitmgkp1o6ug4xads43j6e4gqkj5xk5o83j8ja9php",
+    "previous": "FC5A7FB777110A858052468D448B2DF22B648943C097C0608D1E2341007438B0",
+    "representative": "nano_3p1asma84n8k84joneka776q4egm5wwru3suho9wjsfyuem8j95b3c78nw8j",
+    "balance": "5000000000000000000000000000001",
+    "link": "B2EC73C1F503F47E051AD72ECB512C63BA8E1A0ACC2CEE4EA9A22FE1CBDB693F",
+    "link_as_account": "nano_3eqegh1zc1znhr4joosgsfakrrxtjrf1om3exs9cmajhw97xptbzi3kfba1j",
+    "signature": "90CBD62F5466E35DB3BFE5EFDBC6283BD30C0591A3787C9458D11F2AF6188E45E6E71B5F4A8E3598B1C80080D6024867878E355161AD1935CD757477991D3B0B",
+    "work": "0000000000000000"
+  }
 }
 ```
 
@@ -312,17 +313,17 @@ curl -d '{
 ```json
 {
   "hash": "128106287002E595F479ACD615C818117FCB3860EC112670557A2467386249D4",
-  "block": "{\n
-    \"type\": \"state\",\n
-    \"account\": \"nano_3igf8hd4sjshoibbbkeitmgkp1o6ug4xads43j6e4gqkj5xk5o83j8ja9php\",\n
-    \"previous\": \"597395E83BD04DF8EF30AF04234EAAFE0606A883CF4AEAD2DB8196AAF5C4444F\",\n
-    \"representative\": \"nano_3p1asma84n8k84joneka776q4egm5wwru3suho9wjsfyuem8j95b3c78nw8j\",\n
-    \"balance\": \"3000000000000000000000000000000\",\n
-    \"link\": \"5C2FBB148E006A8E8BA7A75DD86C9FE00C83F5FFDBFD76EAA09531071436B6AF\",\n
-    \"link_as_account\": \"nano_1q3hqecaw15cjt7thbtxu3pbzr1eihtzzpzxguoc37bj1wc5ffoh7w74gi6p\",\n
-    \"signature\": \"D7975EE2F6FAE1FC7DA336FB9DD5F7E30FC1A6825021194E614F0588073D1A4901E34E3CAE8739F1DE2FD85A73D2A0B26F8BE6539E0548C9A45E1C1887BFFC05\",\n
-    \"work\": \"0000000000000000\"\n
-  }\n"
+  "block": {
+    "type": "state",
+    "account": "nano_3igf8hd4sjshoibbbkeitmgkp1o6ug4xads43j6e4gqkj5xk5o83j8ja9php",
+    "previous": "597395E83BD04DF8EF30AF04234EAAFE0606A883CF4AEAD2DB8196AAF5C4444F",
+    "representative": "nano_3p1asma84n8k84joneka776q4egm5wwru3suho9wjsfyuem8j95b3c78nw8j",
+    "balance": "3000000000000000000000000000000",
+    "link": "5C2FBB148E006A8E8BA7A75DD86C9FE00C83F5FFDBFD76EAA09531071436B6AF",
+    "link_as_account": "nano_1q3hqecaw15cjt7thbtxu3pbzr1eihtzzpzxguoc37bj1wc5ffoh7w74gi6p",
+    "signature": "D7975EE2F6FAE1FC7DA336FB9DD5F7E30FC1A6825021194E614F0588073D1A4901E34E3CAE8739F1DE2FD85A73D2A0B26F8BE6539E0548C9A45E1C1887BFFC05",
+    "work": "0000000000000000"
+  }
 }
 ```
 
@@ -356,17 +357,17 @@ curl -d '{
 ```json
 {
   "hash": "2A322FD5ACAF50C057A8CF5200A000CF1193494C79C786B579E0B4A7D10E5A1E",
-  "block": "{\n
-    \"type\": \"state\",\n
-    \"account\": \"nano_3igf8hd4sjshoibbbkeitmgkp1o6ug4xads43j6e4gqkj5xk5o83j8ja9php\",\n
-    \"previous\": \"128106287002E595F479ACD615C818117FCB3860EC112670557A2467386249D4\",\n
-    \"representative\": \"nano_1anrzcuwe64rwxzcco8dkhpyxpi8kd7zsjc1oeimpc3ppca4mrjtwnqposrs\",\n
-    \"balance\": \"3000000000000000000000000000000\",\n
-    \"link\": \"0000000000000000000000000000000000000000000000000000000000000000\",\n
-    \"link_as_account\": \"nano_1111111111111111111111111111111111111111111111111111hifc8npp\",\n
-    \"signature\": \"7E9A7B368DBEB280B01C22633DC82F6CEF00F529E07B76A0232614D2BCDAF85BF52AC9DA4DBE4468B6F144CE82F2FDE44080C8363F903A6EC3D999252CB1E801\",\n
-    \"work\": \"0000000000000000\"\n
-  }\n"
+  "block": {
+    "type": "state",
+    "account": "nano_3igf8hd4sjshoibbbkeitmgkp1o6ug4xads43j6e4gqkj5xk5o83j8ja9php",
+    "previous": "128106287002E595F479ACD615C818117FCB3860EC112670557A2467386249D4",
+    "representative": "nano_1anrzcuwe64rwxzcco8dkhpyxpi8kd7zsjc1oeimpc3ppca4mrjtwnqposrs",
+    "balance": "3000000000000000000000000000000",
+    "link": "0000000000000000000000000000000000000000000000000000000000000000",
+    "link_as_account": "nano_1111111111111111111111111111111111111111111111111111hifc8npp",
+    "signature": "7E9A7B368DBEB280B01C22633DC82F6CEF00F529E07B76A0232614D2BCDAF85BF52AC9DA4DBE4468B6F144CE82F2FDE44080C8363F903A6EC3D999252CB1E801",
+    "work": "0000000000000000"
+  }
 }
 ```
 
@@ -401,17 +402,17 @@ curl -d '{
 ```json
 {
   "hash": "9664412A834F0C27056C7BC4A363FBAE86DF8EF51341A5A5EA14061727AE519F",
-  "block": "{\n
-    \"type\": \"state\",\n
-    \"account\": \"nano_3igf8hd4sjshoibbbkeitmgkp1o6ug4xads43j6e4gqkj5xk5o83j8ja9php\",\n
-    \"previous\": \"2A322FD5ACAF50C057A8CF5200A000CF1193494C79C786B579E0B4A7D10E5A1E\",\n
-    \"representative\": \"nano_3p1asma84n8k84joneka776q4egm5wwru3suho9wjsfyuem8j95b3c78nw8j\",\n
-    \"balance\": \"1000000000000000000000000000000\",\n
-    \"link\": \"5C2FBB148E006A8E8BA7A75DD86C9FE00C83F5FFDBFD76EAA09531071436B6AF\",\n
-    \"link_as_account\": \"nano_1q3hqecaw15cjt7thbtxu3pbzr1eihtzzpzxguoc37bj1wc5ffoh7w74gi6p\",\n
-    \"signature\": \"4D388F982188E337D22E0E66CD24BCABD09BED1E920940C453039B55B6A4724D7BD106019AACC1840480938FF4FA024F041E6E6A32B3641C28E0262025020B03\",\n
-    \"work\": \"0000000000000000\"\n
-  }\n"
+  "block": {
+    "type": "state",
+    "account": "nano_3igf8hd4sjshoibbbkeitmgkp1o6ug4xads43j6e4gqkj5xk5o83j8ja9php",
+    "previous": "2A322FD5ACAF50C057A8CF5200A000CF1193494C79C786B579E0B4A7D10E5A1E",
+    "representative": "nano_3p1asma84n8k84joneka776q4egm5wwru3suho9wjsfyuem8j95b3c78nw8j",
+    "balance": "1000000000000000000000000000000",
+    "link": "5C2FBB148E006A8E8BA7A75DD86C9FE00C83F5FFDBFD76EAA09531071436B6AF",
+    "link_as_account": "nano_1q3hqecaw15cjt7thbtxu3pbzr1eihtzzpzxguoc37bj1wc5ffoh7w74gi6p",
+    "signature": "4D388F982188E337D22E0E66CD24BCABD09BED1E920940C453039B55B6A4724D7BD106019AACC1840480938FF4FA024F041E6E6A32B3641C28E0262025020B03",
+    "work": "0000000000000000"
+  }
 }
 ```
 


### PR DESCRIPTION
Closes #53 .
Closes #70 .

Since the details of the unopened account are not obtained with `account_info` as in the example of receiving, here is a specific subsection for the first receive block.

Also fixes RPC formatting to be more consistent across all RPCs, and uses `json_block` in all RPC samples.