### PR TITLE
Further clarification on relying on RPCs with unconfirmed info for creating transactions

### DIFF
--- a/docs/commands/rpc-protocol.md
+++ b/docs/commands/rpc-protocol.md
@@ -10,7 +10,7 @@ The RPC protocol accepts JSON HTTP POST requests. The following are RPC commands
 ## Node RPCs
 
 !!! warning "Unconfirmed blocks returned"
-    Unless otherwise specified, RPC calls can return unconfirmed blocks and related details. In the most important cases where balances or similar details may include unconfirmed amounts, additional warnings have been included. To confirm a block, refer to _[block_confirm](#block_confirm)_, and to check for confirmation, see _[block_info](#block_info)_.
+    Unless otherwise specified, RPC calls can return unconfirmed blocks and related details. In the most important cases where balances or similar details may include unconfirmed amounts, additional warnings have been included. Refer to [Block confirmation procedures](/integration-guides/key-management/#block-confirmation-procedures) for details.
 
 ---
 
@@ -18,7 +18,7 @@ The RPC protocol accepts JSON HTTP POST requests. The following are RPC commands
 Returns how many RAW is owned and how many have not yet been received by **account**  
 
 --8<-- "unconfirmed-information.md"
-    The pending balance is calculated from potentially unconfirmed blocks. The account's balance is obtained from its frontier. As long as you follow the [guidelines](/integration-guides/key-management/#transaction-order-and-correctness), you can rely on the **balance** for the purposes of creating transactions for this account.
+    The pending balance is calculated from potentially unconfirmed blocks. The account's balance is obtained from its frontier. Prefer using [account_info](#account_info) for the purposes of creating transactions.
 
 **Request:**
 ```json 
@@ -127,7 +127,7 @@ If the `count` limit results in stopping before the end of the account chain, th
 Returns frontier, open block, change representative block, balance, last modified timestamp from local database & block count for **account**. Only works for accounts that have an entry on the ledger, will return "Account not found" otherwise.  
 
 --8<-- "unconfirmed-information.md"
-    The balance is obtained from the frontier, which may be unconfirmed. As long as you follow the [guidelines](/integration-guides/key-management/#transaction-order-and-correctness), you can rely on the **balance** for the purposes of creating transactions for this account.
+    The balance is obtained from the frontier, which may be unconfirmed. As long as you follow the [guidelines](/integration-guides/key-management/#transaction-order-and-correctness), you can rely on the **balance** for the purposes of creating transactions for this account. If the frontier is never confirmed, then the blocks that proceed it will also never be confirmed.
 
 **Request:**
 ```json
@@ -246,7 +246,7 @@ Returns the voting weight for **account**
 Returns how many RAW is owned and how many have not yet been received by **accounts list**  
 
 --8<-- "unconfirmed-information.md"
-    The pending balances are calculated from potentially unconfirmed blocks. Account balances are obtained from their frontiers. As long as you follow the [guidelines](/integration-guides/key-management/#transaction-order-and-correctness), you can rely on the **balance** for the purposes of creating transactions for these accounts.
+    The pending balances are calculated from potentially unconfirmed blocks. Account balances are obtained from their frontiers. Prefer using [account_info](#account_info) for the purposes of creating transactions.
 
 **Request:**
 ```json

--- a/docs/commands/rpc-protocol.md
+++ b/docs/commands/rpc-protocol.md
@@ -10,14 +10,15 @@ The RPC protocol accepts JSON HTTP POST requests. The following are RPC commands
 ## Node RPCs
 
 !!! warning "Unconfirmed blocks returned"
-    Unless otherwise specified, RPC calls can return unconfirmed blocks and related details. In the most important cases where balances or similar details may include unconfirmed amounts, additional warnings have been included.
+    Unless otherwise specified, RPC calls can return unconfirmed blocks and related details. In the most important cases where balances or similar details may include unconfirmed amounts, additional warnings have been included. To confirm a block, refer to _[block_confirm](#block_confirm)_, and to check for confirmation, see _[block_info](#block_info)_.
 
 ---
 
 ### account_balance 
 Returns how many RAW is owned and how many have not yet been received by **account**  
 
---8<-- "includes-unconfirmed.md"
+--8<-- "unconfirmed-information.md"
+    The pending balance is calculated from potentially unconfirmed blocks. The account's balance is obtained from its frontier. As long as you follow the [guidelines](/integration-guides/key-management/#transaction-order-and-correctness), you can rely on the **balance** for the purposes of creating transactions for this account.
 
 **Request:**
 ```json 
@@ -125,7 +126,8 @@ If the `count` limit results in stopping before the end of the account chain, th
 ### account_info
 Returns frontier, open block, change representative block, balance, last modified timestamp from local database & block count for **account**. Only works for accounts that have an entry on the ledger, will return "Account not found" otherwise.  
 
---8<-- "includes-unconfirmed.md"
+--8<-- "unconfirmed-information.md"
+    The balance is obtained from the frontier, which may be unconfirmed. As long as you follow the [guidelines](/integration-guides/key-management/#transaction-order-and-correctness), you can rely on the **balance** for the purposes of creating transactions for this account.
 
 **Request:**
 ```json
@@ -243,7 +245,8 @@ Returns the voting weight for **account**
 ### accounts_balances  
 Returns how many RAW is owned and how many have not yet been received by **accounts list**  
 
---8<-- "includes-unconfirmed.md"
+--8<-- "unconfirmed-information.md"
+    The pending balances are calculated from potentially unconfirmed blocks. Account balances are obtained from their frontiers. As long as you follow the [guidelines](/integration-guides/key-management/#transaction-order-and-correctness), you can rely on the **balance** for the purposes of creating transactions for these accounts.
 
 **Request:**
 ```json
@@ -274,6 +277,8 @@ Returns how many RAW is owned and how many have not yet been received by **accou
 
 ### accounts_frontiers  
 Returns a list of pairs of account and block hash representing the head block for **accounts list**  
+
+--8<-- "includes-unconfirmed.md"
 
 **Request:**
 ```json

--- a/docs/commands/rpc-protocol.md
+++ b/docs/commands/rpc-protocol.md
@@ -18,7 +18,7 @@ The RPC protocol accepts JSON HTTP POST requests. The following are RPC commands
 Returns how many RAW is owned and how many have not yet been received by **account**  
 
 --8<-- "unconfirmed-information.md"
-    The pending balance is calculated from potentially unconfirmed blocks. The account's balance is obtained from its frontier. Prefer using [account_info](#account_info) for the purposes of creating transactions.
+    The pending balance is calculated from potentially unconfirmed blocks. The account's balance is obtained from its frontier. An atomic [account_info](#account_info) RPC call is recommended for the purposes of creating transactions.
 
 **Request:**
 ```json 
@@ -246,7 +246,7 @@ Returns the voting weight for **account**
 Returns how many RAW is owned and how many have not yet been received by **accounts list**  
 
 --8<-- "unconfirmed-information.md"
-    The pending balances are calculated from potentially unconfirmed blocks. Account balances are obtained from their frontiers. Prefer using [account_info](#account_info) for the purposes of creating transactions.
+    The pending balances are calculated from potentially unconfirmed blocks. Account balances are obtained from their frontiers. An atomic [account_info](#account_info) RPC call is recommended for the purposes of creating transactions.
 
 **Request:**
 ```json

--- a/docs/integration-guides/key-management.md
+++ b/docs/integration-guides/key-management.md
@@ -83,9 +83,9 @@ External accounting systems that track balances arriving to the node must track 
 
 #### Transaction order and correctness
 
-Transactions do not directly specify the amount of funds that will be moved, only the remaining balance after the transaction. When creating and processing blocks, ensure that you are the only entity with access to the account's private key, and no two processes are attempting to create blocks for the same account simultaneously. Failing to ensure these conditions could result in the wrong amount being transacted.
+If you are creating a batch of transactions for a single account, which can be a mix of sending and receiving funds, there is no need to wait for the confirmation of blocks **in that account** to create the next transaction. As long as a transaction is valid, it will be confirmed by the network. The transactions that follow it can only be confirmed if the previous transactions are valid.
 
-If you are creating a batch of transactions for a single account, which can be a mix of sending and receiving funds, and the above conditions are ensured, there is no need to wait for the confirmation of the blocks **from that account** to create the next transaction. As long as a transaction is valid, it will be confirmed by the network. The transactions that follow it can only be confirmed if the previous transactions are valid. However, you must always wait for the confirmation of **pending blocks** before creating the corresponding receive transaction.
+However, you must always wait for the confirmation of **pending blocks** before creating the corresponding receive transaction, to ensure it will be confirmed. Always wait for confirmation of transactions that you did not create yourself.
 
 ---
 

--- a/docs/integration-guides/key-management.md
+++ b/docs/integration-guides/key-management.md
@@ -81,7 +81,14 @@ If the need arises to manually trigger a block confirmation, either due to missi
 
 External accounting systems that track balances arriving to the node must track hashes of blocks that have been received in order to guarantee idempotency. Once confirmation of a block has been validated, the block hash should be recorded for the account along with any credits, debits or other related information. Any attempts to credit or debit accounts external to the node should check that no previous conflicting or duplicate activity was already recorded for that same block hash.
 
+#### Transaction order and correctness
+
+Transactions do not directly specify the amount of funds that will be moved, only the remaining balance after the transaction. When creating and processing blocks, ensure that you are the only entity with access to the account's private key, and no two processes are attempting to create blocks for the same account simultaneously. Failing to ensure these conditions could result in the wrong amount being transacted.
+
+If you are creating a batch of transactions for a single account, which can be a mix of sending and receiving funds, and the above conditions are ensured, there is no need to wait for the confirmation of the blocks **from that account** to create the next transaction. As long as a transaction is valid, it will be confirmed by the network. The transactions that follow it can only be confirmed if the previous transactions are valid. However, you must always wait for the confirmation of **pending blocks** before creating the corresponding receive transaction.
+
 ---
+
 ### Expanding Private Keys
 
 A Nano private key is a 256-bit piece of data produced from a cryptographically secure random number generator.
@@ -226,7 +233,7 @@ curl -d '{
 
     When not following this guide closely, the following **inappropriate sequence of events could lead to erroneous amounts sent** to a recipient.
 
-    1. An account's balance, say 5 $nano$, was obtained using the [`account_balance`](/commands/rpc-protocol#account_balance) RPC command (**never use this command for transaction related operations**). This balance is valid as of hypothetical **BLOCK_A**.
+    1. An account's balance, say 5 $nano$, was obtained using the [`account_balance`](/commands/rpc-protocol#account_balance). This balance is valid as of hypothetical **BLOCK_A**.
     1. By another process you control, a receive (**BLOCK_B**) was signed and broadcasted into your account-chain (race-condition).
     * Lets say this `receive` increased the funds on the account chain by 10 $nano$, resulting in a final balance 15 $nano$.
     1. The account's frontier block is obtained by the [`accounts_frontiers`](/commands/rpc-protocol#accounts_frontiers) RPC command, returning the hash of **BLOCK_B**. Other transaction metadata is obtained by other RPC commands.

--- a/docs/snippets/unconfirmed-information.md
+++ b/docs/snippets/unconfirmed-information.md
@@ -1,0 +1,2 @@
+!!! info "Unconfirmed information"
+	This call returns information that may be based on unconfirmed blocks. These details should not be relied on for any process or integration that requires confirmed blocks.  


### PR DESCRIPTION
Explains when we can rely on unconfirmed blocks and balances - if we own the private key of the account in question, and never for pending balances.

Only done for the RPCs we recommend using from the key management guide in order to not bloat the page.