### PR TITLE
Clarify that IPC transport timeouts are in seconds

### DIFF
--- a/docs/running-a-node/configuration.md
+++ b/docs/running-a-node/configuration.md
@@ -188,12 +188,12 @@ On startup, the node will generate configuration options for IPC, one entry for 
    "tcp": {
        "enable": "false",
        "port": "7077",
-       "io_timeout": "15000"
+       "io_timeout": "15" // seconds
    },
    "local": {
        "enable": "false",
        "path": "\/tmp\/nano",
-       "io_timeout": "15000"
+       "io_timeout": "15" // seconds
      }
 },
 ```


### PR DESCRIPTION
Checked the code but please confirm