### PR TITLE
Added note to URI

### DIFF
--- a/docs/integration-guides/the-basics.md
+++ b/docs/integration-guides/the-basics.md
@@ -425,6 +425,8 @@ curl -d '{
 
 Note: `amount` values should always be in RAW.
 
+Note: Please use `nano://` for deep links 
+
 ### Send to an address
 
     nano:nano_<encoded address>[?][amount=<raw amount>][&][label=<label>][&][message=<message>]


### PR DESCRIPTION
Added note for URI. `nano:` is not a valid deep link and `nano://` should be used for deep links