### PR TITLE
Boost backtrace to get detailed stacktrace information

### DIFF
--- a/docs/commands/command-line-interface.md
+++ b/docs/commands/command-line-interface.md
@@ -71,8 +71,13 @@ Profile work verification
 ### --debug_profile_votes
 Profile vote verification
 
+### --debug_stacktrace
+_version 20.0+_
+Prints a stacktrace example, useful to verify that it includes the desired information, such as files, function names and line numbers
+
 ### --debug_validate_blocks
-_version 19.0+_ Validate blocks in the ledger, includes checks for confirmation height
+_version 19.0+_
+Validate blocks in the ledger, includes checks for confirmation height
 
 ### --debug_verify_profile
 Profile signature verification

--- a/docs/integration-guides/build-options.md
+++ b/docs/integration-guides/build-options.md
@@ -116,6 +116,7 @@ Format: `cmake -D VARNAME=VARVALUE`
 * `NANO_SECURE_RPC=ON` (to build node with TLS)
 * `NANO_WARN_TO_ERR=ON` (*v20.0+* turn compiler warnings into errors on Linux/Mac) 
 * `NANO_TIMED_LOCKS=50` (*v20.0+* when the number of milliseconds a mutex is held is equal or greater than this output a stacktrace, 0 disables. If enabled requires the boost `context` & `fiber` libraries)
+* `NANO_STACKTRACE_BACKTRACE=ON` (*v20.0+* uses Boost backtrace in stacktraces, to display filenames, function names and line numbers. Needs `libbacktrace` to be installed. Some [workarounds](https://www.boost.org/doc/libs/develop/doc/html/stacktrace/configuration_and_build.html#stacktrace.configuration_and_build.f3) may be necessary depending on system and configuration. Use CLI [`--debug_stacktrace`](/commands/command-line-interface#-debug_stacktrace) to get an example output.)
 
 **Build Node**
 

--- a/docs/integration-guides/build-options.md
+++ b/docs/integration-guides/build-options.md
@@ -116,7 +116,7 @@ Format: `cmake -D VARNAME=VARVALUE`
 * `NANO_SECURE_RPC=ON` (to build node with TLS)
 * `NANO_WARN_TO_ERR=ON` (*v20.0+* turn compiler warnings into errors on Linux/Mac) 
 * `NANO_TIMED_LOCKS=50` (*v20.0+* when the number of milliseconds a mutex is held is equal or greater than this output a stacktrace, 0 disables. If enabled requires the boost `context` & `fiber` libraries)
-* `NANO_STACKTRACE_BACKTRACE=ON` (*v20.0+* uses Boost backtrace in stacktraces, to display filenames, function names and line numbers. Needs `libbacktrace` to be installed. Some [workarounds](https://www.boost.org/doc/libs/develop/doc/html/stacktrace/configuration_and_build.html#stacktrace.configuration_and_build.f3) may be necessary depending on system and configuration. Use CLI [`--debug_stacktrace`](/commands/command-line-interface#-debug_stacktrace) to get an example output.)
+* `NANO_STACKTRACE_BACKTRACE=ON` (*v20.0+* use a different configuration of Boost backtrace in stacktraces, attempting to display filenames, function names and line numbers. Needs `libbacktrace` to be installed. Some [workarounds](https://www.boost.org/doc/libs/develop/doc/html/stacktrace/configuration_and_build.html#stacktrace.configuration_and_build.f3) may be necessary depending on system and configuration. Use CLI [`--debug_stacktrace`](/commands/command-line-interface#-debug_stacktrace) to get an example output.)
 
 **Build Node**
 


### PR DESCRIPTION
Closes #111 

- `NANO_STACKTRACE_BACKTRACE` cmake option
- `--debug_stacktrace` CLI