### PR TITLE
Updating glossary definitions for unchecked & TPS

### DIFF
--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -15,9 +15,6 @@ A repeating half-second cycle on the node during which votes are collected for a
 #### Block
 A single Nano transaction. All new transactions (e.g. sends, receives, representative changes, etc) on the Nano Protocol are communicated via state blocks (since node V11). The account's entire state, including the balance after each transaction, is recorded in each block. Transaction amounts are interpreted as the difference in balance between consecutive blocks. Before V11, each transaction type (open, send, receive, change) had its own legacy block type.
 
-#### Block
-A single Nano transaction. All new transactions (e.g. sends, receives, representative changes, etc) on the Nano Protocol are communicated via state blocks (since node V11). The account's entire state, including the balance after each transaction, is recorded in each block. Transaction amounts are interpreted as the difference in balance between consecutive blocks. Before V11, each transaction type (open, send, receive, change) had its own legacy block type.
-
 #### block hash
 A 64 character, uppercase hexadecimal string (0-9A-F) value representing a unique block on an account.
 

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -15,6 +15,9 @@ A repeating half-second cycle on the node during which votes are collected for a
 #### Block
 A single Nano transaction. All new transactions (e.g. sends, receives, representative changes, etc) on the Nano Protocol are communicated via state blocks (since node V11). The account's entire state, including the balance after each transaction, is recorded in each block. Transaction amounts are interpreted as the difference in balance between consecutive blocks. Before V11, each transaction type (open, send, receive, change) had its own legacy block type.
 
+#### Block
+A single Nano transaction. All new transactions (e.g. sends, receives, representative changes, etc) on the Nano Protocol are communicated via state blocks (since node V11). The account's entire state, including the balance after each transaction, is recorded in each block. Transaction amounts are interpreted as the difference in balance between consecutive blocks. Before V11, each transaction type (open, send, receive, change) had its own legacy block type.
+
 #### block hash
 A 64 character, uppercase hexadecimal string (0-9A-F) value representing a unique block on an account.
 
@@ -98,9 +101,10 @@ The [account](#account) if the block is the first block on the account, otherwis
 A 256-bit random value usually represented to the user as a 64 character hexidecimal (0-9 and A-F) value. Private keys are derived from a seed.
 
 #### Transactions Per Second (TPS)
-Often used to refer to the rate of complete transactions between two parties (i.e. a send with a corresponding receive). In the past, TPS was a per-node measurement that represented the perceived network-level transmission rate ([BPS](#blocks-per-second-bps)), but this measurement was found to be somewhat inaccurate due to peering and propagation differences between nodes. TPS is now used to refer to ([Confirmations Per Second](#confirmations-per-second-cps)/2) which is more similar to the TPS metric used by other cryptocurrencies (e.g. Bitcoin). Nano sends do not require a corresponding receive to be [confirmed](#confirmation), but receive blocks do need to be confirmed before received funds can be sent again (see [pending](#pending)).
+Historically, TPS was a per-node measurement that represented a node's perception of the rate of transactions on the network ([BPS](#blocks-per-second-bps)). This measurement was found to be inaccurate due to peering and propagation differences between nodes, so [CPS](#confirmations-per-second-cps) is now the preferred term for describing overall Nano network scalability. It's also important to note that while Nano sends do not require a corresponding receive to be [confirmed](#confirmation), a receive block must be confirmed before received funds can be sent again (see [pending](#pending)).
 
 #### unchecked (blocks)
+Blocks (transactions) that have been downloaded but not yet processed by the Nano node. The node software downloads all bocks from other nodes as unchecked, processes them and adds to block count, confirms the [frontier](#frontier) blocks for each account, and then marks them as [cemented](#cementing).
 
 #### unopened account
 An account address that does not have a first block on it (which must be a block to receive Nano sent from another account, cannot be a block only changing the Representative).


### PR DESCRIPTION
Added a definition for unchecked.
Updated the TPS definition to match real world/historical usage (removing "CPS/2")