### PR TITLE
V21 release notes

### DIFF
--- a/docs/releases/network-upgrades.md
+++ b/docs/releases/network-upgrades.md
@@ -6,6 +6,33 @@ For details on why and how network upgrades happen, along with explanations of t
 
 ## Upcoming upgrades
 
+### Increased work difficulty
+
+**Purpose**
+
+To help ensure Quality of Service on the network by increasing the difficulty required for send and change blocks to be considered valid by the network (8x compared to current). To help offset the difficulty increase and add incentive to receive blocks so ledger pruning can be done more broadly in the future, the difficulty for receive blocks will simultaneously be reduced (1/8 compared to current).
+
+**Transition details**
+
+| Date | Type | Description |
+|------|------|-------------|
+| TBD  | Node release | Nano node V21.0 released which includes changes necessary for supporting new difficulty validation and generation |
+| TBD | <span class="no-break">v2 epoch blocks distribution start</span> | Distribution of v2 epoch blocks to all accounts to mark in the ledger the point at which the new work difficulty levels will be required. The start of this distribution process will occur once key services and over 90% of voting weight on the network has upraded. |
+| TBD | <span class="no-break">v2 epoch blocks distribution end</span> | Distribution of epoch blocks ends after all accounts are upgraded. |
+
+!!! warning "Nodes de-peered with epoch blocks"
+	Due to the nature of the work difficulty changes, any nodes not updated to V21.0 at the time of epoch block distribution will be de-peered from the network.
+
+**Transition Explanation**
+
+When changing the work difficulty requirements it is necessary to mark a point in each account where the difficulty requirements change so bootstrapping and other behaviors can accurately validate historical blocks. For this reason the epoch blocks are being distributed to act as the marker in the ledger.
+
+Once epoch block distribution is started the ability to validate the new work difficulty levels is required. Since node versions before V21.0 do not have the ability to do this, they will be immediately de-peered from the network and cannot participate with the current network until upgraded.
+
+To mitigate the impacts of this approach the Nano Foundation will be communicating regularly about progress and monitoring closely the activity on the network. Once acceptable conditions exist to finalize the transition the distribution will begin. The current plan is to start once over 90% of voting weight has been upgraded, along with all the key services on the network.
+
+## Future upgrades
+
 ### New PoW algorithm
 
 **Purpose**

--- a/docs/releases/network-upgrades.md
+++ b/docs/releases/network-upgrades.md
@@ -8,6 +8,8 @@ For details on why and how network upgrades happen, along with explanations of t
 
 ### Increased work difficulty
 
+--8<-- "join-technical-mailing-list.md"
+
 **Purpose**
 
 To help ensure Quality of Service on the network by increasing the difficulty required for send and change blocks to be considered valid by the network (8x compared to current). To help offset the difficulty increase and add incentive to receive blocks so ledger pruning can be done more broadly in the future, the difficulty for receive blocks will simultaneously be reduced (1/8 compared to current).
@@ -23,6 +25,21 @@ To help ensure Quality of Service on the network by increasing the difficulty re
 !!! warning "Nodes de-peered with epoch blocks"
 	Due to the nature of the work difficulty changes, any nodes not updated to V21.0 at the time of epoch block distribution will be de-peered from the network.
 
+In order to best prepare for the transition to new thresholds, the following items should be considered:
+
+* `active_difficulty` [RPC](/commands/rpc-protocol/#work_validate) and [WebSocket topic](/integration-guides/websockets/#active-difficulty) will automatically begin returning the higher difficulty threshold for send/change blocks in the `network_minimum` field once the epoch upgrade begins
+* [`work_validate`](/commands/rpc-protocol/#work_validate) has multiple changes to the response, one which will break most existing integrations when upgrading to V21, two others that will become useful after upgrade:
+    * If `difficulty` parameter is not explicitly passed in the request, the existing `valid` field will not be returned (**breaking**)
+    * `valid_all` is a new return field, `true` if the work is valid at the current default difficulty (will go up after epoch upgrade)
+    * `valid_receive` is a new return field, `true` if the work is valid at the lower epoch_2 receive difficulty (only useful after epoch upgrade)
+    * **If possible, it is best to avoid using this RPC until the epoch upgrade is completed**
+* Testing out work generation capabilities on a machine is recommended. Details for how to accomplish this can be found in the [Benchmark section of the Work Generation guide](/integration-guides/work-generation/#benchmarks).
+
+!!! warning "Calling for frontiers recommended for integrations"
+	Although it is already recommended as best practice, any integrations not already calling for the frontier block when constructing a transaction should do so. If hashes are being internally tracked and frontier is not requested, the integration could unintentionally cause a fork on the account with distribution of epoch blocks.
+
+	See [Step 1: Get Account Info](/integration-guides/key-management/#send-transaction) for the [`account_info`](/commands/rpc-protocol#account_info) RPC recommendation when creating transactions.
+
 **Transition Explanation**
 
 When changing the work difficulty requirements it is necessary to mark a point in each account where the difficulty requirements change so bootstrapping and other behaviors can accurately validate historical blocks. For this reason the epoch blocks are being distributed to act as the marker in the ledger.
@@ -30,6 +47,8 @@ When changing the work difficulty requirements it is necessary to mark a point i
 Once epoch block distribution is started the ability to validate the new work difficulty levels is required. Since node versions before V21.0 do not have the ability to do this, they will be immediately de-peered from the network and cannot participate with the current network until upgraded.
 
 To mitigate the impacts of this approach the Nano Foundation will be communicating regularly about progress and monitoring closely the activity on the network. Once acceptable conditions exist to finalize the transition the distribution will begin. The current plan is to start once over 90% of voting weight has been upgraded, along with all the key services on the network.
+
+---
 
 ## Future upgrades
 

--- a/docs/releases/node-releases.md
+++ b/docs/releases/node-releases.md
@@ -74,25 +74,32 @@ The following versions are no longer peered with by nodes running the active ver
 
 ## Release Notes
 
-### V21.0
-
 --8<-- "setup-beta-testing.md"
+
+### V21.0
 
 !!! info "Nano Forum available"
 	The Nano Forum is available at https://forum.nano.org/ as a resource to ask questions and get support when participating on the network. The [Node and Representative Management category](https://forum.nano.org/c/node-and-rep) is a great place to ask node upgrade related questions. 
 
-!!! info "Join the protocol/node releases and updates mailing list"
-	Follow this link to sign up for email updates on the latest protocol/node releases and other details. This will include network upgrades such as the upcoming epoch distribution: [tbd]
+--8<-- "join-technical-mailing-list.md"
 
 #### Upgrade Notices
 
 The following key upgrade details should be reviewed by all node operators to determine how they will impact plans for upgrading:
 
+**Database upgrades**  
+An in-place database upgrade will occur with this release to accomodate epoch-related flags. Machines will need at least 20-30GB free disk space to accommodate the upgrade.
+
+**--------TODO:** Link to details in Ledger Management guide about managing an upgrade: setting up staging environment for upgrading, getting ledger, etc.
+
+**Minor RPC breaking changes**  
+Although breaking changes were kept to a minimum in this release, there are two RPC calls with such changes: `work_validate` and `bootstrap_status`. For integrations using them, carefully review the additional details on these changes included in the [RPC Updates](#rpc-updates) section below.
+
 **Upcoming v2 epoch upgrade**  
-As outlined in the [February Development Update: V21 PoW Difficulty Increases](https://medium.com/nanocurrency/development-update-v21-pow-difficulty-increases-362b5d052c8e), an epoch block distribution must be done to complete the upgrade to the new work difficulty thresholds. **All integrations generating work are encouraged to the details on the [Network Upgrades page under the Upcoming upgrades section](/releases/network-upgrades#increased-work-difficulty) ahead of the epoch V2 distribution.**
+As outlined in the [February Development Update: V21 PoW Difficulty Increases](https://medium.com/nanocurrency/development-update-v21-pow-difficulty-increases-362b5d052c8e), an epoch block distribution must be done to complete the upgrade to the new work difficulty thresholds. **All integrations generating work are encouraged to review the details on the [Network Upgrades page under the Upcoming upgrades section](/releases/network-upgrades#increased-work-difficulty) ahead of the epoch V2 distribution.**
 
 !!! note "Considerations when using [`active_difficulty`](/commands/rpc-protocol/#active_difficulty) RPC"
-	For external integrations that utilize the difficulty values from the [`active_difficulty`](/commands/rpc-protocol/#active_difficulty) RPC, if you track the `network_minimum` value returned you will see a change from `ffffffc000000000` (pre-epoch v2 difficulty) to `fffffff800000000` (8x higher epoch v2 difficulty).
+	For external integrations that utilize the difficulty values from the [`active_difficulty`](/commands/rpc-protocol/#active_difficulty) RPC, if you track the `network_minimum` value returned you will see a change from `ffffffc000000000` (pre-epoch v2 difficulty) to `fffffff800000000` (8x higher epoch v2 difficulty), an indication the epoch upgrade has begun.
 
 	Once this occurs, send and change blocks should use this newly returned, higher threshold, and receive blocks can optionally use `fffffe0000000000` as the lower threshold going forward.
 
@@ -102,13 +109,6 @@ As outlined in the [February Development Update: V21 PoW Difficulty Increases](h
 	More details about this network upgrade can be found on the [Network Upgrades page under the Upcoming upgrades section](/releases/network-upgrades#increased-work-difficulty)
 
 	**All network participants are encouraged to upgrade to V21.0 as soon as possible to avoid disruption.**
-
-**Database upgrades**  
-An in-place database upgrade will occur with this release to accomodate epoch-related flags. Machines will need at least 20-30GB free disk space to accommodate the upgrade.
-
-TODO: Recommend setting up staging environment to upgrade database or downloading the existing ledger if uptime is an issue as the upgrade process may take 1 hour or longer.
-
-If not enough space is available, the `data.ldb` file can be swapped out for an upgraded version of the ledger. Join the [Nano Discord server](https://chat.nano.org) and go to the `#ledger` channel for a ledger download option.
 
 **UDP disabled by default**  
 With all active peers capable of communicating via TCP, the UDP connections will be disabled by default in this version. To avoid disruptions, all nodes should allow traffic on 7075 TCP (see [Network Ports](/running-a-node/node-setup/#network-ports) details) and once upgraded, the [`peers`](/commands/rpc-protocol/#peers) RPC call should return at least dozens of peers and the [`confirmation_quorum`](/commands/rpc-protocol/#confirmation_quorum) RPC call should have a `peers_stake_total` value in the high tens of millions of Nano.
@@ -120,51 +120,78 @@ Although not recommended, if necessary temporary use of UDP can be done with the
 #### Major Updates
  
 **Work difficulty increase**  
-As mentioned in the [Upgrade Notices](#upgrade-notices) section above, work difficulty changes were implemented in V21, but will not be activated until epoch v2 blocks are distributed at a future date. Please review the [Network Upgrades page under the Upcoming upgrades section](/releases/network-upgrades#increased-work-difficulty) for details.
+As mentioned in the [Upgrade Notices](#upgrade-notices) section above, work difficulty changes were implemented in V21, but will not be activated until epoch v2 blocks are distributed at a future date. Please review the [Upcoming upgrades section](/releases/network-upgrades#increased-work-difficulty) of the Network Upgrades page for details.
 
-Updates on the progress towards 90% voting weight and key service upgrades will be posted in our many social channels as well as sent through our mailing lists which can be joined here: [tbd].
+Updates on the progress toward the epoch upgrade will be posted in our many social channels as well as sent through our technical updates mailing list which can be joined here: http://eepurl.com/gZucL1.
 
-TODO: Note breaking RPC changes
+**Node Telemetry**  
+To allow better communication between nodes about various performance and other details, telemetry was added between peers. Details of what is shared and option to request them can be found within the [`node_telemetry`](/commands/rpc-protocol/#node_telemetry) RPC. Various version details, account and block counts, active difficulty and more can be discovered from individual peers or summarized across them. For protocol level details, see [Node Telemetry section](/protocol-design/networking/#node-telemetry) under Protocol Design > Networking.
 
-**Node Telemetry**
+!!! warning "Telemetry can be forged"
+	Although the telemetry messages are signed by nodes, the values the responses provided can be forged by malicious nodes so they cannot be guaranteed as accurate. All details in these messages should be used as rough indicators of peer and broad network situations, but not exclusively relied on for any key integration or network activities.
 
-**IPC Flatbuffers API**
+Continued conversation around telemetry is happening through the [related forum discussion](https://forum.nano.org/t/node-telemetry-metrics/112/8).
 
-**RocksDB Improvements**
+**IPC 2.0**  
+As a key update towards the upcoming RPC 2.0 redesign, this background upgrade will provide more performant communication to the node, allow easier integration across various languages by supporting Flatbuffers and provide the foundation for [more granular authorization of specific calls](https://github.com/cryptocode/notes/wiki/IPC-Authorization).
 
-**Better election alignment and performance**
-
-
----
-
-#### RPC Updates
-
-* **BREAKING CHANGE** ['work_validate'](/commands/rpc-protocol/#work_validate)
-* **BREAKING CHANGE AFTER EPOCH UPGRADE** ['active_difficulty'](/commands/rpc-protocol/#work_validate)
-
---8<-- "process-sub-type-recommended.md"
-
-#### CLI Updates
-* **NEW** [`generate_config [node|rpc]`](/commands/command-line-interface/#-generate_config-noderpc) prints sample configuration files to *stdout*
-    * `use_defaults` additional argument to generate uncommented entries (not recommended)
-* **NEW** [`config`](/commands/command-line-interface/#-config-keyvalue) passes configuration arguments, alternative to setting in the config file
+**Better election alignment and performance**  
+Behind the scenes many improvements were made to better streamline alignment of elections across the network and allow for better performance. Resource usage by nodes, particularly network bandwidth, will be reduced even further than previous levels. No action is needed to take advantage of this increase other than upgrading your node to V21 as soon as you can!
 
 ---
 
-#### Node Configuration Updates
+#### Node Configuration and Management Updates
 
 !!! info "Support in Nano Forum"
 	For node operators looking to upgrade their node or tune their configurations, the [Node and Representative Management category](https://forum.nano.org/c/node-and-rep) of the forum is a great resource to use.
 
 The following options are notable node configuration updates. Additional configuration changes have been included in this release and can be found when generating the config files.
 
-* 
+* Nodes will now clear their peers lists and online weight if they are started after more than 1 week of being offline. This aims to improve re-peering in these situations, as well as provide more accurate online weight values as the node begins participating on the network again ([related PR](https://github.com/nanocurrency/nano-node/pull/2506)).
+* When `watch_work` is set to `false`, it is no longer required to have [`enable_control`](/running-a-node/configuration/#enable_control) = `true` in the `config-rpc.toml` file.
+
+!!! note "Log when voting, warn multiple accounts"
+	When the node is started there are new messages pushed to the logs which indicate when voting is enabled and how many representatives are configured to vote. A warning will be included in both the logs and `stdout` if multiple representatives are configured to be voting.
+
+---
+
+#### RPC Updates
+
+* **BREAKING CHANGE** [`work_validate`](/commands/rpc-protocol/#work_validate) has multiple changes to the response, one which will break most existing integrations:
+    * If `difficulty` parameter is not explicitly passed in the request, the existing `valid` field will not be returned (**breaking**)
+    * `valid_all` is a new return field, `true` if the work is valid at the current default difficulty (will go up after epoch upgrade)
+    * `valid_receive` is a new return field, `true` if the work is valid at the lower epoch_2 receive difficulty (only useful after epoch upgrade)
+    * **To best understand how these and other epoch related changes will impact your integration, it is highly recommended that the [Upcoming upgrades > Increased work difficulty section](/releases/network-upgrades#increased-work-difficulty) of the Network Upgrades is carefully reviewed**
+* `active_difficulty` [RPC](/commands/rpc-protocol/#work_validate) and [WebSocket](/integration-guides/websockets/#active-difficulty) will automatically begin returning the higher difficulty threshold for send/change blocks in the `network_minimum` field once the epoch upgrade begins, otherwise the response formats will remain the same
+* **BREAKING CHANGE** [`bootstrap_status`](/commands/rpc-protocol/#bootstrap_status) responses now have `connections` field as an array of connection-related fields and adds an `attempts` field with an area of individual bootstrap attempt details, each including information such as a unique id, type of bootstrap (legacy, lazy) and various other granular information.
+* [`account_info`](/commands/rpc-protocol/#account_info) responses now contain `confirmation_height_frontier` which is the hash of the last confirmed block.
+**----------TODO:** Add brief details about how this is helpful to integrations...
+
+--8<-- "process-sub-type-recommended.md"
+
+#### CLI Updates
+* **NEW** [`--generate_config [node|rpc]`](/commands/command-line-interface/#-generate_config-noderpc) prints sample configuration files to *stdout*
+    * `use_defaults` additional argument to generate uncommented entries (not recommended)
+* **NEW** [`--config`](/commands/command-line-interface/#-config-keyvalue) passes configuration arguments, alternative to setting in the config file
+* **NEW** [`--inactive_votes_cache_size`](/commands/command-line-interface/#-inactive_votes_cache_size) allows adjusting of the cache that holds votes where the block is does not have an action election, default is 16384 votes
+* **NEW** [`--rebuild_database`](/commands/command-line-interface/#-rebuild_database) provides a better compaction method for LMDB. **NOTE:** This requires approximately `data.ldb` file size * 2 in free space on disk.
+* **NEW** [`--compare_rep_weights`](/commands/command-line-interface/#-compare_rep_weights) gives the ability to compare the current ledger voting weight distribution against the hard coded weights provided in the node on release. Useful when attempting to use a downloaded ledger. More details on use on [Ledger Management page](/running-a-node/ledger-management)
+
+---
+
+#### WebSockets
+
+* Updates to WebSocket subscriptions are now allowed on the [`confirmation`](/integration-guides/websockets/#confirmations) topic. With `options` of `accounts_add` and `accounts_del` an existing subscription can now be more easily managed to avoid cancelling and resubscribing or managing multiple subscriptions.
+* **NEW** [`bootstrap`](/integration-guides/websockets/#bootstrap) topic provides notifications about the starting and exiting of bootstrap attempts.
+* **NEW** [`new_unconfirmed_block`](/integration-guides/websockets/#new_unconfirmed_block) topic provides notifications about blocks which were just processed and are being seen by the node for the first time. This is useful for integrations that want to watch for blocks they didn't create themselves, but for which they want to update with new work (external work watcher).
 
 ---
 
 #### Developer/Debug Options
 
-* 
+* [`confirmation_active`](/commands/rpc-protocol/#confirmation_active) RPC response includes new `unconfirmed` and `confirmed` fields to help with more granular election tracking and monitoring
+* When the node is started there are new messages pushed to the logs which indicate when voting is enabled and how many representatives are configured to vote. A warning will be included in both the logs and `stdout` if multiple representatives are configured to be voting.
+* New [`--debug_generate_crash_report`](/commands/command-line-interface/#-debug_generate_crash_report) CLI command consumes the dump files to create a helpful crash report. See [What to do if the node crashes (Linux)](/running-a-node/troubleshooting/#what-to-do-if-the-node-crashes-linux) for more details on using this command.
 
 ---
 
@@ -260,8 +287,11 @@ As part of the original implementation work we were able to setup infrastructure
 * [`peers`](/commands/rpc-protocol/#peers) and [`node_id`](/commands/rpc-protocol/#node_id) now return node IDs with a `node_` prefix
 * [work_generate](/commands/rpc-protocol/#work_generate) and [work_validate](/commands/rpc-protocol/#work_validate) can now take a multiplier (against base difficulty) to set a different difficulty threshold
 
-<span class="h4-no-toc">CLI Updates
-* **NEW** [`generate_config [node|rpc]`](/commands/command-line-interface/#-generate_config-noderpc) prints sample configuration files to *stdout*
+---
+
+<span class="h4-no-toc">CLI Updates</span>
+
+* **NEW** [`generate_config [node|rpc]`](/commands/command-line-interface/#-generate_config-noderpc) prints sample configuration files to _stdout_
     * `use_defaults` additional argument to generate uncommented entries (not recommended)
 * **NEW** [`config`](/commands/command-line-interface/#-config-keyvalue) passes configuration arguments, alternative to setting in the config file
 

--- a/docs/releases/node-releases.md
+++ b/docs/releases/node-releases.md
@@ -76,6 +76,8 @@ The following versions are no longer peered with by nodes running the active ver
 
 ### V21.0
 
+--8<-- "setup-beta-testing.md"
+
 !!! info "Nano Forum available"
 	The Nano Forum is available at https://forum.nano.org/ as a resource to ask questions and get support when participating on the network. The [Node and Representative Management category](https://forum.nano.org/c/node-and-rep) is a great place to ask node upgrade related questions. 
 

--- a/docs/releases/node-releases.md
+++ b/docs/releases/node-releases.md
@@ -10,13 +10,11 @@ The following release is the latest and only release actively supported by the N
 
 | Node Version | Protocol Version | Release Date | Release Notes | GitHub Links | 
 |              |                  |              |               | 					|
-| 20.0         | 17               | 2019-11-12          | [V20.0](/releases/node-releases/#v200) | [Release](https://github.com/nanocurrency/nano-node/releases/tag/V20.0) - [Milestone](https://github.com/nanocurrency/nano-node/milestone/10) - [Changelog](https://github.com/nanocurrency/nano-node/compare/V19.0...V20.0) | 
-
-**Builds and Commands**
-
---8<-- "known-issue-peers-stake-reporting.md"
+| 21.0         | 18               | TBD          | [V21.0](/releases/node-releases/#v210) | [Release](https://github.com/nanocurrency/nano-node/releases/tag/V21.0) - [Milestone](https://github.com/nanocurrency/nano-node/milestone/18) - [Changelog](https://github.com/nanocurrency/nano-node/compare/V20.0...V21.0) | 
 
 --8<-- "known-issue-macos-too-many-open-files.md"
+
+**Builds and Commands**
 
 --8<-- "current-release-build-links.md"
 
@@ -27,7 +25,7 @@ The following release is currently under development. Details about potential fe
 
 | Node Version | Protocol Version | Release Date | Release Notes | GitHub Links | 
 |              |                  |              |               | 				|
-| 21.0         | TBD              | TBD          | TBD			 | Release - [Milestone](https://github.com/nanocurrency/nano-node/milestone/18) - Changelog | 
+| 22.0         | TBD              | TBD          | TBD			 | Release - [Milestone](https://github.com/nanocurrency/nano-node/milestone/19) - Changelog | 
 
 ---
 
@@ -38,7 +36,8 @@ The following releases can still actively participate on the network by peering 
 |              |                  |              |               | 					|
 | 20.0         | 17               | 2019-11-12          | [V20.0](/releases/node-releases/#v200) | [Release](https://github.com/nanocurrency/nano-node/releases/tag/V20.0) - [Milestone](https://github.com/nanocurrency/nano-node/milestone/10) - [Changelog](https://github.com/nanocurrency/nano-node/compare/V19.0...V20.0) | 
 | 19.0 | 17 | 2019-07-11 | [V19.0](/releases/node-releases/#v190) | [Release](https://github.com/nanocurrency/nano-node/releases/tag/V19.0) - [Milestone](https://github.com/nanocurrency/nano-node/milestone/9) - [Changelog](https://github.com/nanocurrency/nano-node/compare/V18.0...V19.0) | 
-| 18.0 | 16 | 2019-02-21 || [Release](https://github.com/nanocurrency/nano-node/releases/tag/V18.0) - [Milestone](https://github.com/nanocurrency/nano-node/milestone/7) - [Changelog](https://github.com/nanocurrency/nano-node/compare/V17.1...V18.0) |
+
+--8<-- "known-issue-peers-stake-reporting.md"
 
 --8<-- "known-issue-macos-too-many-open-files.md"
 
@@ -51,6 +50,7 @@ The following versions are no longer peered with by nodes running the active ver
 
 	| Node Version | Protocol Version | Release Date | Release Notes | GitHub Links |
 	|              |                  |              |               |              |
+	| 18.0 | 16 | 2019-02-21 || [Release](https://github.com/nanocurrency/nano-node/releases/tag/V18.0) - [Milestone](https://github.com/nanocurrency/nano-node/milestone/7) - [Changelog](https://github.com/nanocurrency/nano-node/compare/V17.1...V18.0) |
 	| 17.1 | 15 | 2018-12-21 || [Release](https://github.com/nanocurrency/nano-node/releases/tag/V17.1) - [Milestone](https://github.com/nanocurrency/nano-node/milestone/17) - [Changelog](https://github.com/nanocurrency/nano-node/compare/V17.0...V17.1) |
 	| 17.0 | 15 | 2018-12-18 || [Release](https://github.com/nanocurrency/nano-node/releases/tag/V17.0) - [Milestone](https://github.com/nanocurrency/nano-node/milestone/6) - [Changelog](https://github.com/nanocurrency/nano-node/compare/V16.3...V17.0) |
 	| 16.3 | 14 | 2018-11-20 || [Release](https://github.com/nanocurrency/nano-node/releases/tag/V16.3) - [Milestone](https://github.com/nanocurrency/nano-node/milestone/14) - [Changelog](https://github.com/nanocurrency/nano-node/compare/V16.2...V16.3) |
@@ -74,12 +74,112 @@ The following versions are no longer peered with by nodes running the active ver
 
 ## Release Notes
 
+### V21.0
+
+!!! info "Nano Forum available"
+	The Nano Forum is available at https://forum.nano.org/ as a resource to ask questions and get support when participating on the network. The [Node and Representative Management category](https://forum.nano.org/c/node-and-rep) is a great place to ask node upgrade related questions. 
+
+!!! info "Join the protocol/node releases and updates mailing list"
+	Follow this link to sign up for email updates on the latest protocol/node releases and other details. This will include network upgrades such as the upcoming epoch distribution: [tbd]
+
+#### Upgrade Notices
+
+The following key upgrade details should be reviewed by all node operators to determine how they will impact plans for upgrading:
+
+**Upcoming v2 epoch upgrade**  
+As outlined in the [February Development Update: V21 PoW Difficulty Increases](https://medium.com/nanocurrency/development-update-v21-pow-difficulty-increases-362b5d052c8e), an epoch block distribution must be done to complete the upgrade to the new work difficulty thresholds. **All integrations generating work are encouraged to the details on the [Network Upgrades page under the Upcoming upgrades section](/releases/network-upgrades#increased-work-difficulty) ahead of the epoch V2 distribution.**
+
+!!! note "Considerations when using [`active_difficulty`](/commands/rpc-protocol/#active_difficulty) RPC"
+	For external integrations that utilize the difficulty values from the [`active_difficulty`](/commands/rpc-protocol/#active_difficulty) RPC, if you track the `network_minimum` value returned you will see a change from `ffffffc000000000` (pre-epoch v2 difficulty) to `fffffff800000000` (8x higher epoch v2 difficulty).
+
+	Once this occurs, send and change blocks should use this newly returned, higher threshold, and receive blocks can optionally use `fffffe0000000000` as the lower threshold going forward.
+
+!!! danger "Only node V21.0 will be active after epoch distribution"
+	Nodes upgrading to V21.0 will remain peered with nodes V19.0 and V20.0 on the network until the epoch v2 block distribution begins. **After the first epoch v2 block is distributed, all nodes not running V21.0 will no longer be able to participate on the network.** This distribution will occur once 90% of voting weight and key services on the network have upgraded. Communications around the progress towards this goal will be sent following the release.
+
+	More details about this network upgrade can be found on the [Network Upgrades page under the Upcoming upgrades section](/releases/network-upgrades#increased-work-difficulty)
+
+	**All network participants are encouraged to upgrade to V21.0 as soon as possible to avoid disruption.**
+
+**Database upgrades**  
+An in-place database upgrade will occur with this release to accomodate epoch-related flags. Machines will need at least 20-30GB free disk space to accommodate the upgrade.
+
+TODO: Recommend setting up staging environment to upgrade database or downloading the existing ledger if uptime is an issue as the upgrade process may take 1 hour or longer.
+
+If not enough space is available, the `data.ldb` file can be swapped out for an upgraded version of the ledger. Join the [Nano Discord server](https://chat.nano.org) and go to the `#ledger` channel for a ledger download option.
+
+**UDP disabled by default**  
+With all active peers capable of communicating via TCP, the UDP connections will be disabled by default in this version. To avoid disruptions, all nodes should allow traffic on 7075 TCP (see [Network Ports](/running-a-node/node-setup/#network-ports) details) and once upgraded, the [`peers`](/commands/rpc-protocol/#peers) RPC call should return at least dozens of peers and the [`confirmation_quorum`](/commands/rpc-protocol/#confirmation_quorum) RPC call should have a `peers_stake_total` value in the high tens of millions of Nano.
+
+Although not recommended, if necessary temporary use of UDP can be done with the new [`--enable_udp`](/commands/command-line-interface/#-enable_udp) flag.
+
+---
+
+#### Major Updates
+ 
+**Work difficulty increase**  
+As mentioned in the [Upgrade Notices](#upgrade-notices) section above, work difficulty changes were implemented in V21, but will not be activated until epoch v2 blocks are distributed at a future date. Please review the [Network Upgrades page under the Upcoming upgrades section](/releases/network-upgrades#increased-work-difficulty) for details.
+
+Updates on the progress towards 90% voting weight and key service upgrades will be posted in our many social channels as well as sent through our mailing lists which can be joined here: [tbd].
+
+TODO: Note breaking RPC changes
+
+**Node Telemetry**
+
+**IPC Flatbuffers API**
+
+**RocksDB Improvements**
+
+**Better election alignment and performance**
+
+
+---
+
+#### RPC Updates
+
+* **BREAKING CHANGE** ['work_validate'](/commands/rpc-protocol/#work_validate)
+* **BREAKING CHANGE AFTER EPOCH UPGRADE** ['active_difficulty'](/commands/rpc-protocol/#work_validate)
+
+--8<-- "process-sub-type-recommended.md"
+
+#### CLI Updates
+* **NEW** [`generate_config [node|rpc]`](/commands/command-line-interface/#-generate_config-noderpc) prints sample configuration files to *stdout*
+    * `use_defaults` additional argument to generate uncommented entries (not recommended)
+* **NEW** [`config`](/commands/command-line-interface/#-config-keyvalue) passes configuration arguments, alternative to setting in the config file
+
+---
+
+#### Node Configuration Updates
+
+!!! info "Support in Nano Forum"
+	For node operators looking to upgrade their node or tune their configurations, the [Node and Representative Management category](https://forum.nano.org/c/node-and-rep) of the forum is a great resource to use.
+
+The following options are notable node configuration updates. Additional configuration changes have been included in this release and can be found when generating the config files.
+
+* 
+
+---
+
+#### Developer/Debug Options
+
+* 
+
+---
+
+#### Deprecations
+
+The following functionality is now deprecated and will be removed in a future release:
+
+* UDP is disabled by default in this version and will be removed in a future release. Launch flag [`--disable_udp`](/commands/command-line-interface/#-disable_udp-deprecated) is deprecated and temporary use of UDP can be done with the new [`--enable_udp`](/commands/command-line-interface/#-enable_udp) flag.
+
+---
+
 ### V20.0
 
 !!! info "Nano Forum available"
 	The Nano Forum is available at https://forum.nano.org/ as a resource to ask questions and get support when participating on the network. The [Node and Representative Management category](https://forum.nano.org/c/node-and-rep) is a great place to ask node upgrade related questions. 
 
-#### Upgrade Notices
+<span class="h4-no-toc">Upgrade Notices</span>
 
 !!! warning "Only node V18.0 and higher supported"
 	With V20.0 only nodes V18.0 and higher will be peered with on the network (see [Active Releases](/releases/node-releases/#active-releases) above). This means any nodes running versions earlier than 18.0 will begin to lose peers and fall out of sync over time once upgrades to V20.0 begin.
@@ -125,7 +225,7 @@ Improvements to the [External Management](https://docs.nano.org/integration-guid
 
 ---
 
-#### Major Updates
+<span class="h4-no-toc">Major Updates</span>
  
 **Migration to .toml config files**  
 Better legibility, support for comments, and no more having the node write to your config files are some of the benefits of this upgrade. Any non-default values captured in your existing .json files will be migrated and you can export a full list of configuration options for use with simple commands. See additional callouts in [Upgrade Notices](#upgrade-notices) above and in the node [Configuration documentation](https://docs.nano.org/running-a-node/configuration/).
@@ -147,7 +247,7 @@ As part of the original implementation work we were able to setup infrastructure
 
 ---
 
-#### RPC Updates
+<span class="h4-no-toc">RPC Updates</span>
 
 * **BEHAVIOR CHANGE** [`process`](/commands/rpc-protocol/#process) now takes an optional flag `watch_work` (default `true`). Unless set to `false`, processed blocks can be subject to PoW rework
 * **BEHAVIOR CHANGE** [`bootstrap`](/commands/rpc-protocol/#bootstrap), [`bootstrap_any`](/commands/rpc-protocol/#bootstrap_any) and [`boostrap_lazy`](/commands/rpc-protocol/#bootstrap_lazy) will now throw errors when certain launch flags are used to disabled bootstrap methods - see each RPC page for details
@@ -158,14 +258,14 @@ As part of the original implementation work we were able to setup infrastructure
 * [`peers`](/commands/rpc-protocol/#peers) and [`node_id`](/commands/rpc-protocol/#node_id) now return node IDs with a `node_` prefix
 * [work_generate](/commands/rpc-protocol/#work_generate) and [work_validate](/commands/rpc-protocol/#work_validate) can now take a multiplier (against base difficulty) to set a different difficulty threshold
 
-#### CLI Updates
+<span class="h4-no-toc">CLI Updates
 * **NEW** [`generate_config [node|rpc]`](/commands/command-line-interface/#-generate_config-noderpc) prints sample configuration files to *stdout*
     * `use_defaults` additional argument to generate uncommented entries (not recommended)
 * **NEW** [`config`](/commands/command-line-interface/#-config-keyvalue) passes configuration arguments, alternative to setting in the config file
 
 ---
 
-#### Node Configuration Updates
+<span class="h4-no-toc">Node Configuration Updates</span>
 
 !!! info "Support in Nano Forum"
 	For node operators looking to upgrade to V20.0 or tune their configurations, the [Node and Representative Management category](https://forum.nano.org/c/node-and-rep) of the forum is a great resource to use.
@@ -181,7 +281,7 @@ The following options are notable node configuration updates. Additional configu
 
 ---
 
-#### Developer/Debug Options
+<span class="h4-no-toc">Developer/Debug Options</span>
 
 * New RPC [`epoch_upgrade`](/commands/rpc-protocol/#epoch_upgrade) allowing easier epoch distribution (**Note** - this epoch requires a special private key to be used, see the [Network Upgrades](/releases/network-upgrades/#epoch-blocks) page for information)
 * RPC [`bootstrap`](/commands/rpc-protocol/#bootstrap) has a new optional "bypass_frontier_confirmation"
@@ -199,7 +299,7 @@ The following options are notable node configuration updates. Additional configu
 
 ---
 
-#### Deprecations
+<span class="h4-no-toc">Deprecations</span>
 
 The following functionality is now deprecated and will be removed in a future release:
 

--- a/docs/snippets/current-release-build-links.md
+++ b/docs/snippets/current-release-build-links.md
@@ -1,7 +1,7 @@
 | OS | Download link/command |
 |----|---------------|
-| Linux | https://repo.nano.org/live/binaries/nano-node-V20.0-Linux.tar.bz2 |
-| macOS | https://repo.nano.org/live/binaries/nano-node-V20.0-Darwin.dmg |
-| Windows | https://repo.nano.org/live/binaries/nano-node-V20.0-win64.exe |
-| Docker | `docker pull nanocurrency/nano:V20.0` or `docker pull nanocurrency/nano:latest`<br />See [Pulling the Docker Image](/running-a-node/node-setup/#pulling-the-docker-image) for more details. |
+| Linux | https://repo.nano.org/live/binaries/nano-node-V21.0-Linux.tar.bz2 |
+| macOS | https://repo.nano.org/live/binaries/nano-node-V21.0-Darwin.dmg |
+| Windows | https://repo.nano.org/live/binaries/nano-node-V21.0-win64.exe |
+| Docker | `docker pull nanocurrency/nano:V21.0` or `docker pull nanocurrency/nano:latest`<br />See [Pulling the Docker Image](/running-a-node/node-setup/#pulling-the-docker-image) for more details. |
 | RHEL/CentOS rpm | `sudo yum-config-manager --add-repo https://repo.nano.org/nanocurrency.repo`<br />`sudo yum install nanocurrency`<br />This installs `nano_node` to bin. |

--- a/docs/snippets/join-technical-mailing-list.md
+++ b/docs/snippets/join-technical-mailing-list.md
@@ -1,0 +1,2 @@
+!!! info "Join the technical updates mailing list"
+	Follow this link to sign up for email updates on the latest protocol/node releases and other technical details. This will include network upgrades such as the upcoming epoch distribution: http://eepurl.com/gZucL1

--- a/docs/snippets/known-issue-macos-too-many-open-files.md
+++ b/docs/snippets/known-issue-macos-too-many-open-files.md
@@ -1,4 +1,4 @@
-??? warning "Known Issue: macOS 'Too many open files'"
+??? warning "Known Issue V19+: macOS 'Too many open files'"
 
     * **Issue:** The following error can be seen when attempting to run a full node on macOS using the built-in Qt wallet or other GUI-based wallets: "Exception while running wallet: open: Too many open files". This is due to macOS having a very low default file descriptor limit and V19.0 uses more of them after the move to TCP.
     

--- a/docs/snippets/known-issue-peers-stake-reporting.md
+++ b/docs/snippets/known-issue-peers-stake-reporting.md
@@ -1,4 +1,4 @@
-??? warning "Known Issue: Peers stake reporting inaccurate (Windows only)"
+??? warning "Known Issue V20: Peers stake reporting inaccurate (Windows only)"
 
     * **Issue:** For Windows builds only, when calling [confirmation_quorum RPC](/commands/rpc-protocol/#confirmation_quorum) the `peers_stake_total` amount returned may be inaccurate, returning a range from the correct full peer stake amount down to 0.
 

--- a/docs/snippets/setup-beta-testing.md
+++ b/docs/snippets/setup-beta-testing.md
@@ -1,0 +1,2 @@
+!!! info "Setup for testing on beta network"
+	If you are looking to test the latest version of the node ahead of release, check out the [Beta Network](/running-a-node/beta-network/) page for more details about how to get setup. Testing specific features, integrations and anything else is highly encouraged during all stages of node development.


### PR DESCRIPTION
Closes #222 

- [ ] Release Notes reference #270
- [ ] Listed as "TODO" in Release Notes: link to details in #264 
- [ ] List as "TODO" in Release Notes: add details about usefulness of `confirmation_height_frontier` in `account_info` call
- [ ] Double-check node configuration items are complete - compare V20 and V21 default configs?
- [ ] Verify all links work properly in Node Releases > Release Notes > V21.0
- [ ] Verify all links work properly in Network Upgrades > Upcoming upgrades > Increased work difficulty