### PR TITLE
Deprecate the term Mac OSX. Use macOS instead

### DIFF
--- a/docs/integration-guides/build-options.md
+++ b/docs/integration-guides/build-options.md
@@ -233,7 +233,7 @@ cp nano_node ../nano_node && cd .. && ./nano_node --diagnostics
 
 ---
 
-## Build Instructions - OSX
+## Build Instructions - macOS
 
 --8<-- "unsupported-configuration.md"
 

--- a/docs/running-a-node/troubleshooting.md
+++ b/docs/running-a-node/troubleshooting.md
@@ -7,7 +7,7 @@ The default location of standard node log files for various systems:
 | **OS**  | **Location** |
 |---------|--------------|
 | Windows | `:::bash C:\Users\<user>\AppData\Local\Nano\log` -or- `:::bash %LOCALAPPDATA%\Nano\log`  |
-| OSX     | `:::bash /Users/<user>/Library/Nano/log ` |
+| macOS   | `:::bash /Users/<user>/Library/Nano/log ` |
 | Linux   | `:::bash /home/<user>/Nano/log ` |
 
 ---

--- a/docs/snippets/beta-folder-locations.md
+++ b/docs/snippets/beta-folder-locations.md
@@ -1,5 +1,5 @@
 | **OS**  | **Location** |
 |---------|--------------|
 | Windows | `:::bash C:\Users\<user>\AppData\Local\NanoBeta\` |
-| OSX     | `:::bash /Users/<user>/Library/NanoBeta/ ` |
+| macOS   | `:::bash /Users/<user>/Library/NanoBeta/ ` |
 | Linux   | `:::bash /home/<user>/NanoBeta/ ` |

--- a/docs/snippets/folder-locations.md
+++ b/docs/snippets/folder-locations.md
@@ -1,5 +1,5 @@
 | **OS**  | **Location** |
 |---------|--------------|
 | Windows | `:::bash C:\Users\<user>\AppData\Local\Nano\` |
-| OSX     | `:::bash /Users/<user>/Library/Nano/ ` |
+| macOS   | `:::bash /Users/<user>/Library/Nano/ ` |
 | Linux   | `:::bash /home/<user>/Nano/ ` |


### PR DESCRIPTION
In 2012, with the release of OS X 10.8 Mountain Lion, the name of the
system was shortened from Mac OS X to OS X. In 2016, with the release
of macOS 10.12 Sierra, the name was changed from OS X to macOS to
streamline it with the branding of Apple's other primary operating
systems: iOS, watchOS, and tvOS.

Reference: https://en.wikipedia.org/wiki/MacOS