### PR TITLE
Specify some Nano cryptopgraphic functions details

### DIFF
--- a/docs/integration-guides/the-basics.md
+++ b/docs/integration-guides/the-basics.md
@@ -59,10 +59,10 @@ Wallet implementations will commonly start from index 0 and increment it by 1 ea
 This is also a 32 byte value, usually represented as a 64 character, uppercase hexadecimal string(0-9A-F). It can either be random (an *ad-hoc key*) or derived from a seed, as described above. This is what represents control of a specific account on the ledger. If you know or can know the private key of someone's account, you can transact as if you own that account.
 
 ### Account public key
-This is also a 32 byte value, usually represented as a 64 character, uppercase hexadecimal string (0-9A-F). It is derived from an *account private key* by using the ed25519 curve using blake2b as the hash function (instead of sha). Usually account public keys will not be passed around in this form, rather the below address is used.
+This is also a 32 byte value, usually represented as a 64 character, uppercase hexadecimal string (0-9A-F). It is derived from an *account private key* by using the ED25519 curve using Blake2b-512 as the hash function (instead of SHA-512). Usually account public keys will not be passed around in this form, rather the below address is used.
 
 ### Account public address
-This is what you think of as someone's Nano address: it's a string that starts with `nano_` (previously `xrb_`), then has 52 characters which are the *account public key* but encoded with a specific base32 encoding algorithm to prevent human transcription errors by limiting ambiguity between different characters (no `O` and `0` for example). Then the final 8 characters are a checksum of the account public key to aid in discovering typos, also encoded with the same base32 scheme.
+This is what you think of as someone's Nano address: it's a string that starts with `nano_` (previously `xrb_`), then has 52 characters which are the *account public key* but encoded with a specific base32 encoding algorithm to prevent human transcription errors by limiting ambiguity between different characters (no `O` and `0` for example). Then the final 8 characters are Blake2b-40 checksum of the account public key to aid in discovering typos, also encoded with the same base32 scheme (5 bytes).
 
 So for address `nano_1anrzcuwe64rwxzcco8dkhpyxpi8kd7zsjc1oeimpc3ppca4mrjtwnqposrs`:
 

--- a/docs/integration-guides/the-basics.md
+++ b/docs/integration-guides/the-basics.md
@@ -55,7 +55,7 @@ Private keys are derived **deterministically** from the seed, which means that a
 
 Wallet implementations will commonly start from index 0 and increment it by 1 each time you create a new account so that recovering accounts is as easy as importing the seed and then repeating this account creation process.
 
-It should be noted that Nano reference wallet is using described Blake2b private keys derivation path. However some implementations can use BIP44 deterministic wallets and [menmonic seed](/integration-guides/key-management/#mnemonic-seed) producing different private keys for given seed and indices. Additionally 24-word mnemonic can be derived from a Nano 64 length hex seed as entropy with clear notice for users that this is not BIP44 seed.
+It should be noted that Nano reference wallet is using described Blake2b private keys derivation path. However some implementations can use BIP44 deterministic wallets and [menmonic seed](/integration-guides/key-management/#mnemonic-seed) producing different private keys for given seed and indices. Additionally 24-word mnemonic can be derived from a Nano 64 length hex seed as entropy with clear notice for users that this is not BIP44 seed/entropy.
 
 ??? info "Code samples"
 

--- a/docs/integration-guides/the-basics.md
+++ b/docs/integration-guides/the-basics.md
@@ -55,7 +55,7 @@ Private keys are derived **deterministically** from the seed, which means that a
 
 Wallet implementations will commonly start from index 0 and increment it by 1 each time you create a new account so that recovering accounts is as easy as importing the seed and then repeating this account creation process.
 
-It should be noted that Nano reference wallet is using described Blake2b private keys derivation path. However some implementations can use BIP44 deterministic wallets and [menmonic seed](/integration-guides/key-management/#mnemonic-seed). Additionally 24-word mnemonic can be derived from a Nano 64 length hex seed as entropy with clear notice for users that this is not BIP44 seed.
+It should be noted that Nano reference wallet is using described Blake2b private keys derivation path. However some implementations can use BIP44 deterministic wallets and [menmonic seed](/integration-guides/key-management/#mnemonic-seed) producing different private keys for given seed and indices. Additionally 24-word mnemonic can be derived from a Nano 64 length hex seed as entropy with clear notice for users that this is not BIP44 seed.
 
 ??? info "Code samples"
 

--- a/docs/integration-guides/the-basics.md
+++ b/docs/integration-guides/the-basics.md
@@ -65,7 +65,9 @@ It should be noted that Nano reference wallet is using described Blake2b private
 	seed = b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01" # "0000000000000000000000000000000000000000000000000000000000000001"
 	index = 0x00000001.to_bytes(4, 'big') # 1
 	blake2b_state = hashlib.blake2b(digest_size=32)
-	blake2b_state.update(seed+index) # equal to blake2b_state.update(seed); blake2b_state.update(index)
+	blake2b_state.update(seed+index)
+	# where `+` means concatenation, not sum: https://docs.python.org/3/library/hashlib.html#hashlib.hash.update
+	# code line above is equal to `blake2b_state.update(seed); blake2b_state.update(index)`
 	PrivK = blake2b_state.digest()
 	print(blake2b_state.hexdigest().upper()) # "1495F2D49159CC2EAAAA97EBB42346418E1268AFF16D7FCA90E6BAD6D0965520"
 	```

--- a/docs/integration-guides/work-generation.md
+++ b/docs/integration-guides/work-generation.md
@@ -113,7 +113,7 @@ The `"work"` field in transactions contains a 64-bit [nonce](https://en.wikipedi
 
 **Block Height 1**
 
-The first block on an account-chain doesn't have a previous (head) block, so the account public key is used:
+The first block on an account-chain doesn't have a previous (head) block, so the account public key is used (`||` means concatenation):
 
 $$
 blake2b(\text{nonce} || \text{public_key}) \ge \text{threshold}

--- a/docs/protocol-design/overview.md
+++ b/docs/protocol-design/overview.md
@@ -33,7 +33,7 @@ Make sure you have the correct [Boost version](https://github.com/nanocurrency/n
 
 | **Name**                        | **Details** |
 |                                 |             |
-| cryptopp                        | Provides the implementation for blake2, AES and other cryptographic schemes. |
+| cryptopp                        | Provides the implementation for random number generator, SipHash, AES and other cryptographic schemes. |
 | phc&#x2011;winner&#x2011;argon2 | When encrypting with AES, the password first goes through key derivation, and argon2 is our hash of choice for doing that. |
 | lmdb     			              | The database library used for the ledger and wallet, with local patches for Windows. This is a very fast and portable key/value store with ordered keys. It is extremely resilient to crashes in the program, OS, and power-downs without corruption. |
 | miniupnp 			              | This library is used to do port mapping if the gateway supports it. |

--- a/docs/protocol-design/signing-hashing-and-key-derivation.md
+++ b/docs/protocol-design/signing-hashing-and-key-derivation.md
@@ -22,7 +22,7 @@ Compared to existing cryptocurrencies, the hash algorithm chosen is much less im
 
 ### Key derivation function: Argon2
 
-The key derivation function of Argon2 is used for securing the account keys in the reference wallet. [^3]
+The key derivation function of Argon2d version 1.0 is used for securing the account keys in the reference wallet. [^3]
 
 [^1]:http://ed25519.cr.yp.to/
 [^2]:https://blake2.net/

--- a/docs/protocol-design/signing-hashing-and-key-derivation.md
+++ b/docs/protocol-design/signing-hashing-and-key-derivation.md
@@ -2,7 +2,7 @@
 
 ### Signing algorithm: ED25519
 
-ED25519 is an elliptic curve algorithm developed in an academic setting with a focus on security from side channel attack, performance, and fixing a lot of the little annoyances in most elliptic curve systems[^1]. However, it should be noted that instead of using SHA-512 in the key derivation function, Nano uses Blake2b.
+ED25519 is an elliptic curve algorithm developed in an academic setting with a focus on security from side channel attack, performance, and fixing a lot of the little annoyances in most elliptic curve systems[^1]. However, it should be noted that instead of using SHA-512 in the key derivation function, Nano uses Blake2b-512.
 
 !!! failure "Incorrect, SHA-512 has been used"
   ```
@@ -10,7 +10,7 @@ ED25519 is an elliptic curve algorithm developed in an academic setting with a f
   3B6A27BCCEB6A42D62A3A8D02A6F0D73653215771DE243A63AC048A18B59DA29
   ```
 
-!!! success "Correct, Blake2b digested the seed"
+!!! success "Correct, Blake2b-512 digested the seed"
   ```
   0000000000000000000000000000000000000000000000000000000000000000 ->
   19D3D919475DEED4696B5D13018151D1AF88B2BD3BCFF048B45031C1F36D1858
@@ -18,7 +18,7 @@ ED25519 is an elliptic curve algorithm developed in an academic setting with a f
 
 ### Hashing algorithm: Blake2
 
-Compared to existing cryptocurrencies, the hash algorithm chosen is much less important since it's not being used in a [Proof-of-Work](/glossary#proof-of-work-pow) context.  In Nano hashing is used purely as a digest algorithm against block contents.  Blake2 is a highly optimized cryptographic hash function whose predecessor was a SHA3 finalist.[^2]
+Compared to existing cryptocurrencies, the hash algorithm chosen is much less important since it's not being used in a [Proof-of-Work](/glossary#proof-of-work-pow) context.  In Nano hashing is used purely as a digest algorithm against block contents.  Blake2b-512 is a highly optimized cryptographic hash function whose predecessor was a SHA3 finalist.[^2]
 
 ### Key derivation function: Argon2
 

--- a/docs/protocol-design/signing-hashing-and-key-derivation.md
+++ b/docs/protocol-design/signing-hashing-and-key-derivation.md
@@ -18,7 +18,7 @@ ED25519 is an elliptic curve algorithm developed in an academic setting with a f
 
 ### Hashing algorithm: Blake2
 
-Compared to existing cryptocurrencies, the hash algorithm chosen is much less important since it's not being used in a [Proof-of-Work](/glossary#proof-of-work-pow) context.  In Nano hashing is used purely as a digest algorithm against block contents.  Blake2b-512 is a highly optimized cryptographic hash function whose predecessor was a SHA3 finalist.[^2]
+Compared to existing cryptocurrencies, the hash algorithm chosen is much less important since it's not being used in a [Proof-of-Work](/glossary#proof-of-work-pow) context.  In Nano hashing is used purely as a digest algorithm against block contents.  Blake2b-256 is a highly optimized cryptographic hash function whose predecessor was a SHA3 finalist.[^2]
 
 ### Key derivation function: Argon2
 


### PR DESCRIPTION
* Blake2b lengths (output digests can be from 8 up to 512 bit). Ed25519 is using 512, block hash 256, accounts checksum 40.
* Specific Argon2 version (Argon2d ver. 1.0).
* Extra notice about blake2b concatenation usage for key derivation from seed (with python sample).
* Mnemonic seed reference from basics.