### PR TITLE
Fix broken links to work generation related configs

### DIFF
--- a/docs/integration-guides/work-generation.md
+++ b/docs/integration-guides/work-generation.md
@@ -28,10 +28,10 @@ Although the node can be configured to generate work directly, there are plans t
 
 ### Number of work peers
 
-To provide a more robust and redundant work generation setup, multiple [work peers](/running-a-node/configuration/#nodework_peers) can be used. Any node configured with multiple peers will make requests serially from the list of work peers until a successful response is received.
+To provide a more robust and redundant work generation setup, multiple [work peers](#nodework_peers) can be used. Any node configured with multiple peers will make requests serially from the list of work peers until a successful response is received.
 
 !!! tip "Disable local CPU work generation"
-	Since using the same CPU resources the node relies on for work generation can cause performance issues, local CPU work generation should be turned off by setting [`node.work_threads`](/running-a-node/configuration/#nodework_threads) = `0` when using work peers.
+	Since using the same CPU resources the node relies on for work generation can cause performance issues, local CPU work generation should be turned off by setting [`node.work_threads`](#nodework_threads) = `0` when using work peers.
 
 ## Recommended configurations
 
@@ -49,10 +49,10 @@ Services with heavy RPC calls and work generation can benefit from ensuring dedi
 1. Install the [Nano Work Server](https://github.com/nanocurrency/nano-work-server/blob/master/README.md#installation)
 1. Setup a service to start and monitor the work server process using the GPU option `--gpu <PLATFORM:DEVICE>` and run `nano-work-server --help` for additional options and details
 1. Configure the machine running the node to allow traffic over TCP from the work generation machine's IP address
-1. Add the work machine IP address as a [work peer](/running-a-node/configuration/#nodework_peers) in the node's `config-node.toml` file
+1. Add the work machine IP address as a [work peer](#nodework_peers) in the node's `config-node.toml` file
 
 !!! info "CPU for lower generation levels"
-	For services with heavier RPC usage but less work generation needs excluding the GPU in the above example and relying on the CPU resources of the separate machine is also an option. This can be done by setting [`node.work_threads`](/running-a-node/configuration/#nodework_threads) to the appropriate thread count for your needs.
+	For services with heavier RPC usage but less work generation needs excluding the GPU in the above example and relying on the CPU resources of the separate machine is also an option. This can be done by setting [`node.work_threads`](#nodework_threads) to the appropriate thread count for your needs.
 
 	Make sure to benchmark the machine performance to plan for any potential spikes, as CPU generation is slower.
 
@@ -62,10 +62,10 @@ Services where RPC usage is lighter but regular work generation is needed could 
 
 1. Install the [Nano Work Server](https://github.com/nanocurrency/nano-work-server/blob/master/README.md#installation) on the same machine as the node
 1. Setup a service to start and monitor the work server process with options for using the GPU - `--gpu <PLATFORM:DEVICE:THREADS>` is required, run `nano-work-server --help` for additional options and details
-1. Configure the node to prevent local CPU work generation by setting [`node.work_threads`](/running-a-node/configuration/#nodework_threads) = `0`
+1. Configure the node to prevent local CPU work generation by setting [`node.work_threads`](#nodework_threads) = `0`
 
 !!! info "Node work generation option"
-	A less preferred alternative to setting up, running and monitoring the Nano Work Server is to use the node itself to generate work. This should only be done with an attached GPU by setting up and enabling OpenCL with [`opencl.enable`](/running-a-node/configuration/#openclenable) = `true` and adusting `opencl.device` and `opencl.platform` to match your setup.
+	A less preferred alternative to setting up, running and monitoring the Nano Work Server is to use the node itself to generate work. This should only be done with an attached GPU by setting up and enabling OpenCL with [`node.opencl.enable`](#nodeopenclenable) = `true` and adusting `node.opencl.device` and `node.opencl.platform` to match your setup.
 
 ---
 
@@ -112,7 +112,7 @@ graph TD
 
 The following configuration options can be changed in `node-config.toml`. For more information on the location of this file, and general information on the configuration of the node, see the [Configuration](/running-a-node/configuration/) page.
 
-### opencl.enable
+### node.opencl.enable
 
 !!!success "When GPU acceleration is enabled, the CPU is also used by default"
 	Make sure to set `node.work_threads` to `0` when using the GPU
@@ -218,7 +218,7 @@ The developer wallet included with the node is configured to pre-cache work at t
 For services aiming to ensure the highest priority on their transactions, the confirmation of published blocks should be monitored by their integration and work levels compared against active difficulty in a similar fashion to the development wallet mentioned above. If work is left at base difficulty there could be delays in the transactions being processed during heavy network usage times.
 
 !!! tip "Configure max work generate multiplier"
-    Due to the possibility of network work levels increasing beyond the capabilities of certain work generation setups, the config option [`node.max_work_generate_multiplier`](/running-a-node/configuration/#nodemax_work_generate_multiplier) can be used to limit how high a work value will be requested at. All setups, whether using the developer wallet or an external integration, should implement an appropriate limit which defaults to 64x in V20.
+    Due to the possibility of network work levels increasing beyond the capabilities of certain work generation setups, the config option [`node.max_work_generate_multiplier`](#nodemax_work_generate_multiplier) can be used to limit how high a work value will be requested at. All setups, whether using the developer wallet or an external integration, should implement an appropriate limit which defaults to 64x in V20.
 
 !!! warning "Upcoming threshold changes and variations by block type"
 	  Plans are underway to change the thresholds based on the type of block with the release of V21 and subsequent distribution of v2 epoch blocks to enable the feature. See the [Development Update: V21 PoW Difficulty Increases article](https://medium.com/nanocurrency/development-update-v21-pow-difficulty-increases-362b5d052c8e) for full details.

--- a/docs/releases/node-releases.md
+++ b/docs/releases/node-releases.md
@@ -151,7 +151,7 @@ As part of the original implementation work we were able to setup infrastructure
 
 * **BEHAVIOR CHANGE** [`process`](/commands/rpc-protocol/#process) now takes an optional flag `watch_work` (default `true`). Unless set to `false`, processed blocks can be subject to PoW rework
 * **BEHAVIOR CHANGE** [`bootstrap`](/commands/rpc-protocol/#bootstrap), [`bootstrap_any`](/commands/rpc-protocol/#bootstrap_any) and [`boostrap_lazy`](/commands/rpc-protocol/#bootstrap_lazy) will now throw errors when certain launch flags are used to disabled bootstrap methods - see each RPC page for details
-* **BEHAVIOR CHANGE** RPCs requiring work generation will now throw errors when work generation is disabled (no [work peers](/running-a-node/configuration/#nodework_peers), no [OpenCL](/running-a-node/configuration/#openclenable) and no work threads configured)
+* **BEHAVIOR CHANGE** RPCs requiring work generation will now throw errors when work generation is disabled (no [work peers](/integration-guides/work-generation/#nodework_peers), no [OpenCL](/integration-guides/work-generation/#nodeopenclenable) and no work threads configured)
 * [`block_count`](/commands/rpc-protocol/#block_count) no longer requires config option `enable_control` to get the cemented block count
 * [`unchecked`](/commands/rpc-protocol/#unchecked) now takes an optional flag `json_block` to return blocks in JSON-format
 * [`version`](/commands/rpc-protocol/#version) now includes more fields - network label, identifier (hash of the genesis open block) and build information

--- a/docs/snippets/hardware-recommendations.md
+++ b/docs/snippets/hardware-recommendations.md
@@ -22,4 +22,4 @@ The following are minimum recommended specifications for nodes with less than 0.
 !!! tip "Proof-of-Work Generation"
 	For nodes being used with services requiring regular or high volume sending and receiving of transactions, special considerations must be made for handling Proof-of-Work generation activities.
 
-	GPUs provide much higher throughput than CPUs. [Work peers](/running-a-node/configuration/#work_peers) can also be configured for generating work outside the node.
+	GPUs provide much higher throughput than CPUs. [Work peers](/integration-guides/work-generation/#nodework_peers) can also be configured for generating work outside the node.


### PR DESCRIPTION
Also changes `openc.enable` to the full `node.opencl.enable` to be consistent.