### PR TITLE
Fall back to IPv4 address if IPv6 is not available

### DIFF
--- a/docs/integration-guides/advanced.md
+++ b/docs/integration-guides/advanced.md
@@ -286,6 +286,9 @@ The choice depends on the setup and security that you want. The easiest way is t
 
     curl -g -d '{ "action": "block_count" }' '[::1]:7076'
 
+!!! tip
+    If you get `curl: (7) Couldn't connect to server`, replace `[::1]:7076` with `127.0.0.1:7076`.
+
 **To stop node, use**   
 
     curl -g -d '{ "action": "stop" }' '[::1]:7076'

--- a/docs/running-a-node/docker-management.md
+++ b/docs/running-a-node/docker-management.md
@@ -205,6 +205,6 @@ For other commands, review the [RPC Protocol](/commands/rpc-protocol) details.
 
 ### Troubleshooting
 
-If you get `Error starting userland proxy: port is not a proto:IP:port: 'tcp:[:'.` or want to expose IPv4 port, use `-p 127.0.0.1:7076:7076`.
+If you get `Error starting userland proxy: port is not a proto:IP:port: 'tcp:[:'.` or want to expose IPv4 port, use `-p 127.0.0.1:7076:7076`. Likewise, if you get `curl: (7) Couldn't connect to server` when interacting with the node, replace `[::1]:7076` with `127.0.0.1:7076`.
 
 If you get `create ~: volume name is too short, names should be at least two alphanumeric characters.` replace the `~` with the full pathname such as `/Users/someuser`.


### PR DESCRIPTION
The documentation mentions several IPv6 addresses, but it lacked of
an appropriate explanation about the fallback on IPv4.