### PR TITLE
Clarify valgrind and sanitizers as dynamic analysis tools

### DIFF
--- a/docs/protocol-design/overview.md
+++ b/docs/protocol-design/overview.md
@@ -172,7 +172,7 @@ Your code will be reviewed with security in mind, but please do your part before
     * Avoid using ANSI C functions. Many of these are prone to buffer overruns.
     * Avoid using C strings and direct buffer manipulation.
 
-* Use static analysis tools, such as valgrind, XCode instrumentation, linters and sanitizers. These tools are also great for debugging crashes and performance problems.
+* Use static and dynamic analysis tools, such as valgrind, XCode instrumentation, linters and sanitizers. These tools are also great for debugging crashes and performance problems.
 
 ### General tips for contributors
 


### PR DESCRIPTION
Valgrind is a generic framework for creating dynamic analysis tools
such as checkers and profilers. And, the sanitizer suite shipped with
LLVM and GCC provides compilation-based dynamic analysis tools. Both
are not static analysis tools.