### PR TITLE
Clarify telemetry endpoints return data from other nodes by default

### DIFF
--- a/docs/commands/rpc-protocol.md
+++ b/docs/commands/rpc-protocol.md
@@ -2396,7 +2396,8 @@ Boolean, false by default. Returns a consecutive list of block hashes in the acc
 
 ### telemetry
 _version 21.0+_  
-Return metrics from nodes. See [networking node telemetry](/protocol-design/networking#node-telemetry) for more information.    
+Return metrics from other nodes on the network. By default, returns a summarized view of the whole network. See below for details on obtaining local telemetry data.  
+[Networking - node telemetry](/protocol-design/networking#node-telemetry) contains more detailed information on the protocol implementation of telemetry.  
 **Request:**
 ```json
 {
@@ -2489,7 +2490,9 @@ Get metrics from a specific peer. It accepts both ipv4 and ipv6 addresses
   "port": "7075"
 }
 ```
-Metrics for the local node can be requested using the peering port and any loopback address **127.0.0.1**, **::1** or **[::1]**
+
+!!!tip "Requesting telemetry data from the local node"
+    Metrics for the local node can be requested using the peering port and any loopback address **localhost**, **127.0.0.1**, **::1** or **[::1]**
 
 ---
 

--- a/docs/commands/rpc-protocol.md
+++ b/docs/commands/rpc-protocol.md
@@ -2492,7 +2492,7 @@ Get metrics from a specific peer. It accepts both ipv4 and ipv6 addresses
 ```
 
 !!!tip "Requesting telemetry data from the local node"
-    Metrics for the local node can be requested using the peering port and any loopback address **localhost**, **127.0.0.1**, **::1** or **[::1]**
+    Metrics for the local node can be requested using the peering port and any loopback address **127.0.0.1**, **::1** or **[::1]**
 
 ---
 

--- a/docs/integration-guides/websockets.md
+++ b/docs/integration-guides/websockets.md
@@ -520,7 +520,7 @@ This subscription is available since _v21.0_
 
 ##### Subscribing
 
-To subscribe to node telemetry response notifications:
+To subscribe to telemetry response notifications from **other nodes on the network**:
 
 ```json
 {
@@ -563,7 +563,7 @@ No filters are currently available for the `telemetry` topic.
   }
 }
 ```
-See the [telemetry](../commands/rpc-protocol.md#telemetry) RPC command which gives more information about the message response  
+See the [telemetry](../commands/rpc-protocol.md#telemetry) RPC command which gives more information about the message response.  
 
 
 ### New unconfirmed blocks


### PR DESCRIPTION
To prevent misuse of the default version of this RPC to get local node data.