### PR TITLE
network_receive_minimum/current in active_difficulty endpoints

### DIFF
--- a/docs/commands/rpc-protocol.md
+++ b/docs/commands/rpc-protocol.md
@@ -413,7 +413,7 @@ Boolean, false by default. Only returns blocks which have their confirmation hei
 ### active_difficulty
 _version 19.0+_ 
 
-Returns the difficulty values (16 hexadecimal digits string, 64 bit) for the minimum required on the network (`network_minimum`) as well as the current active difficulty seen on the network (`network_current`, 10 second trended average of adjusted difficulty seen on prioritized transactions) which can be used to perform rework for better prioritization of transaction processing. A multiplier of the `network_current` from the base difficulty of `network_minimum` is also provided for comparison.
+Returns the difficulty values (16 hexadecimal digits string, 64 bit) for the minimum required on the network (`network_minimum`) as well as the current active difficulty seen on the network (`network_current`, 10 second trended average of adjusted difficulty seen on prioritized transactions) which can be used to perform rework for better prioritization of transaction processing. A multiplier of the `network_current` from the base difficulty of `network_minimum` is also provided for comparison. `network_receive_minimum` is also provided as a lower threshold exclusively for receive blocks. This does not work fr
 
 **Request:**
 ```json
@@ -425,9 +425,10 @@ Returns the difficulty values (16 hexadecimal digits string, 64 bit) for the min
 **Response:**
 ```json
 {
-  "network_minimum": "ffffffc000000000",
-  "network_current": "ffffffcdbf40aa45",
-  "multiplier": "1.273557846739298"
+  "multiplier": "1.273557846739298",
+  "network_current": "fffffff9b7e81549",
+  "network_minimum": "fffffff800000000",
+  "network_receive_minimum": "fffffe0000000000" // since V21.2
 }
 ```
 
@@ -447,9 +448,7 @@ Note: Before v20, the sampling period was between 16 and 36 seconds.
 **Response:**
 ```json
 {
-  "network_minimum": "ffffffc000000000",
-  "network_current": "ffffffc1816766f2",
-  "multiplier": "1.024089858417128",
+  ...,
   "difficulty_trend": [
     "1.156096135149775",
     "1.190133894573061",

--- a/docs/commands/rpc-protocol.md
+++ b/docs/commands/rpc-protocol.md
@@ -413,7 +413,7 @@ Boolean, false by default. Only returns blocks which have their confirmation hei
 ### active_difficulty
 _version 19.0+_ 
 
-Returns the difficulty values (16 hexadecimal digits string, 64 bit) for the minimum required on the network (`network_minimum`) as well as the current active difficulty seen on the network (`network_current`, 10 second trended average of adjusted difficulty seen on prioritized transactions) which can be used to perform rework for better prioritization of transaction processing. A multiplier of the `network_current` from the base difficulty of `network_minimum` is also provided for comparison. `network_receive_minimum` is also provided as a lower threshold exclusively for receive blocks. This does not work fr
+Returns the difficulty values (16 hexadecimal digits string, 64 bit) for the minimum required on the network (`network_minimum`) as well as the current active difficulty seen on the network (`network_current`, 10 second trended average of adjusted difficulty seen on prioritized transactions) which can be used to perform rework for better prioritization of transaction processing. A multiplier of the `network_current` from the base difficulty of `network_minimum` is also provided for comparison. `network_receive_minimum` and `network_receive_current` are also provided as lower thresholds exclusively for receive blocks.
 
 **Request:**
 ```json
@@ -425,9 +425,10 @@ Returns the difficulty values (16 hexadecimal digits string, 64 bit) for the min
 **Response:**
 ```json
 {
-  "multiplier": "1.273557846739298",
-  "network_current": "fffffff9b7e81549",
+  "multiplier": "1.5",
+  "network_current": "fffffffaaaaaaaab",
   "network_minimum": "fffffff800000000",
+  "network_receive_current": "fffffff07c1f07c2", // since V21.2
   "network_receive_minimum": "fffffe0000000000" // since V21.2
 }
 ```

--- a/docs/integration-guides/websockets.md
+++ b/docs/integration-guides/websockets.md
@@ -440,9 +440,10 @@ No filters are currently available for the `active_difficulty` topic.
   "topic": "active_difficulty",
   "time": "1561661736065",
   "message": {
-    "network_minimum": "ffffffc000000000",
-    "network_current": "ffffffc81644d01f",
-    "multiplier": "1.144635159892734"
+    "multiplier": "1.273557846739298",
+    "network_current": "fffffff9b7e81549",
+    "network_minimum": "fffffff800000000",
+    "network_receive_minimum": "fffffe0000000000" // since V21.2
   }
 }
 ```

--- a/docs/integration-guides/websockets.md
+++ b/docs/integration-guides/websockets.md
@@ -440,9 +440,10 @@ No filters are currently available for the `active_difficulty` topic.
   "topic": "active_difficulty",
   "time": "1561661736065",
   "message": {
-    "multiplier": "1.273557846739298",
-    "network_current": "fffffff9b7e81549",
+    "multiplier": "1.5",
+    "network_current": "fffffffaaaaaaaab",
     "network_minimum": "fffffff800000000",
+    "network_receive_current": "fffffff07c1f07c2", // since V21.2
     "network_receive_minimum": "fffffe0000000000" // since V21.2
   }
 }

--- a/docs/integration-guides/work-generation.md
+++ b/docs/integration-guides/work-generation.md
@@ -241,9 +241,6 @@ For services aiming to ensure the highest priority on their transactions, the co
 !!! tip "Configure max work generate multiplier"
     Due to the possibility of network work levels increasing beyond the capabilities of certain work generation setups, the config option [`node.max_work_generate_multiplier`](#nodemax_work_generate_multiplier) can be used to limit how high a work value will be requested at. All setups, whether using the developer wallet or an external integration, should implement an appropriate limit which defaults to 64x in V20.
 
-!!! warning "Upcoming threshold changes and variations by block type"
-	  Plans are underway to change the thresholds based on the type of block with the release of V21 and subsequent distribution of v2 epoch blocks to enable the feature. See the [Development Update: V21 PoW Difficulty Increases article](https://medium.com/nanocurrency/development-update-v21-pow-difficulty-increases-362b5d052c8e) for full details.
-
 ### Pre-caching
 
 Work for an account can be pre-cached and saved for immediate use on an account as long as it was based on the current frontier block at the time of use. Although this customization must be made externally to the node, it can help level out potential spikes in work generation, especially useful with wallet implementations.
@@ -259,7 +256,6 @@ With V21+ the work difficulty thresholds were split by block type. For many inte
 **Utilizing lower work when batching**
 
 For services that process receiving their pending transactions in bulk the lower work threshold of receive blocks can be taken advantage of. In doing so, the difficulty is 64x lower than a send/change block, but the difficulty will be normalized for proper prioritization if published during heavy network load times.
-
 
 ### Difficulty multiplier
 

--- a/docs/integration-guides/work-generation.md
+++ b/docs/integration-guides/work-generation.md
@@ -91,7 +91,7 @@ graph TD
 graph TD
     M{Access to a node?} -->|yes| N[active_difficulty <a href='/commands/rpc-protocol/#active_difficulty'><b>RPC</b></a> or <a href='/integration-guides/websockets/#active-difficulty'><b>WS</b></a>]
     M --> |no| O_1(<a href='/protocol-design/networking/#node-telemetry'><b>Telemetry</b></a>)
-    N -->|network_minimum| P_1(Generate work at<br><b>network_minimum</b> difficulty)
+    N -->P_1(Generate work at<br><b>network_minimum</b><br>or <b>network_receive_minimum</b><br>difficulty)
     O_1 -->O_2((active<br>difficulty))
     P_1 -->|work| P_2(Use <b>work</b> in block)
     P_2 -->P_3((block))

--- a/docs/integration-guides/work-generation.md
+++ b/docs/integration-guides/work-generation.md
@@ -87,11 +87,14 @@ graph TD
 
 ### Work generated without using the node
 
+!!!tip "Lower thresholds for receive blocks"
+    **Receive blocks** benefit from a lower work threshold. In the following guide, replace uses of `network_minimum` and `network_current` with `network_receive_minimum` and `network_receive_current`, respectively, to benefit from the lower threshold.
+
 ``` mermaid
 graph TD
     M{Access to a node?} -->|yes| N[active_difficulty <a href='/commands/rpc-protocol/#active_difficulty'><b>RPC</b></a> or <a href='/integration-guides/websockets/#active-difficulty'><b>WS</b></a>]
     M --> |no| O_1(<a href='/protocol-design/networking/#node-telemetry'><b>Telemetry</b></a>)
-    N -->P_1(Generate work at<br><b>network_minimum</b><br>or <b>network_receive_minimum</b><br>difficulty)
+    N -->P_1(Generate work at<br><b>network_minimum</b> difficulty)
     O_1 -->O_2((active<br>difficulty))
     P_1 -->|work| P_2(Use <b>work</b> in block)
     P_2 -->P_3((block))
@@ -99,7 +102,7 @@ graph TD
     P_4 -->P_5(<a href='/integration-guides/block-confirmation-tracking/'>Track block confirmation</a>)
     P_5 -->P_6{Block unconfirmed<br>after 5 seconds?}
     P_6 -->P_7[active_difficulty <a href='/commands/rpc-protocol/#active_difficulty'><b>RPC</b></a> or <a href='/integration-guides/websockets/#active-difficulty'><b>WS</b></a>]
-    P_7 -->|network_current| P_8{Block difficulty less<br>than <b>network_current</b> ?}
+    P_7 -->P_8{Block difficulty less<br>than <b>network_current</b> ?}
     P_8 -->|yes| P_9(Generate work at<br><b>network_current</b> difficulty)
     P_8 -->|no| P_6
     P_9 -->|updated_work| P_10(Use <b>updated_work</b> in <b>block</b>)


### PR DESCRIPTION
For https://github.com/nanocurrency/nano-node/pull/2903

@zhyatt do you think explaining the use of `network_receive_minimum` in other sections of the work generation guide is preferable?