### PR TITLE
Switch build to generic mkdocs material theme to support PRs from forks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ jobs:
         with:
           python-version: 3.x
       - run: pip install -r requirements.txt
-      - run: pip install git+https://${GH_TOKEN}@github.com/squidfunk/mkdocs-material-insiders.git
+      - run: pip install mkdocs-material
       - run: mkdocs build --strict
 
 env:


### PR DESCRIPTION
Forks for the repo don't have access to the GitHub Actions secrets so using the special MKDocs Material insiders theme was causing build checks to fail. This reverts back to the regular mkdocs material theme for the initial build, using the insiders on deploy.