### PR TITLE
Update wrong block subtype in process request

### DIFF
--- a/docs/integration-guides/key-management.md
+++ b/docs/integration-guides/key-management.md
@@ -445,7 +445,7 @@ curl -d '{
 curl -d '{
   "action": "process",
   "json_block": "true",
-  "subtype": "send",
+  "subtype": "open",
   "block": {
     "type": "state",
     "account": "nano_1rawdji18mmcu9psd6h87qath4ta7iqfy8i4rqi89sfdwtbcxn57jm9k3q11",


### PR DESCRIPTION
Since in the request example given on the page regarding process RPC call is referred to special block subtype of open:

```bash
curl -d '{
  "action": "process",
  "json_block": "true",
  "subtype": "send",
  "block": {
    "type": "state",
    "account": "nano_1rawdji18mmcu9psd6h87qath4ta7iqfy8i4rqi89sfdwtbcxn57jm9k3q11",
    "previous": "0000000000000000000000000000000000000000000000000000000000000000",
    "representative": "nano_1stofnrxuz3cai7ze75o174bpm7scwj9jn3nxsn8ntzg784jf1gzn1jjdkou",
    "balance": "100",
    "link": "5B2DA492506339C0459867AA1DA1E7EDAAC4344342FAB0848F43B46D248C8E99",
    "link_as_account": "nano_1psfnkb71rssr34sisxc5piyhufcrit68iqtp44ayixnfnkas5nsiuy58za7",
    "signature": "903991714A55954D15C91DB75CAE2FBF1DD1A2D6DA5524AA2870F76B50A8FE8B4E3FBB53E46B9E82638104AAB3CFA71CFC36B7D676B3D6CAE84725D04E4C360F",
    "work": "08d09dc3405d9441"
  }
}' http://127.0.0.1:7076
```

Which is clearly visible by the frontier:

```bash
 "previous": "0000000000000000000000000000000000000000000000000000000000000000"
```

The line containing subtype:
```bash
 "subtype": "send"
```

Cannot be of a subtype send since the previous balance will always be lower than the new balance. And 0 frontier refers to open state block.

Suggested edit:
```bash
"subtype": "open"
```

If any edits are required let me know.

Link to the reference:
[https://docs.nano.org/integration-guides/key-management/#broadcasting-transactions](https://docs.nano.org/integration-guides/key-management/#broadcasting-transactions)