### PR TITLE
Fix typo fluctuate

### DIFF
--- a/docs/protocol-design/introduction.md
+++ b/docs/protocol-design/introduction.md
@@ -29,7 +29,7 @@ To date, the Nano network has processed more than 53 million transactions with a
 In 2008, an anonymous individual under the pseudonym Satoshi Nakamoto published a whitepaper outlining the world’s first decentralized cryptocurrency, Bitcoin [^1]. A key innovation brought about by Bitcoin was the blockchain, a public, immutable and decentralized data-structure which is used as a ledger for the currency’s transactions. Unfortunately, as Bitcoin matured, several issues in the protocol made Bitcoin prohibitive for many applications: 
 
 1. Poor scalability: Each block in the blockchain can store a limited amount of data, which means the system can only process so many transactions per second, making
-spots in a block a commodity. Median transaction fees flucutate between a few cents and as high as \$34 (currently ~\$2.98 as of August 26, 2020) [^4].
+spots in a block a commodity. Median transaction fees fluctuate between a few cents and as high as \$34 (currently ~\$2.98 as of August 26, 2020) [^4].
 
 2. High latency: Average confirmation times fluctuate between 10 and 300 minutes [^5]. In addition, most Bitcoin services require more than one confirmation before considering a transaction fully-settled [^6], which adds additional latency for end users.
 


### PR DESCRIPTION
Found a typo in the Protocol Design section on the docs. 