### PR TITLE
Replaced reference to Repnode.org with Nanoticker.info

### DIFF
--- a/docs/protocol-design/orv-consensus.md
+++ b/docs/protocol-design/orv-consensus.md
@@ -100,7 +100,7 @@ This implementation decision was made in part because of the exponential bandwid
 
 ## Quorum
 
-[^1]: "Block Confirmation Times", 2020. [Online]. Available: https://repnode.org/network/confirmation 
+[^1]: "Block Confirmation Times", 2021. [Online]. Available: https://nanoticker.info 
 [^2]: C. LeMahieu, "Emergent centralization due to economies of scale", 2020. [Online]. Available: https://medium.com/@clemahieu/emergent-centralization-due-to-economies-of-scale-83cc85a7cbef
 [^3]: Srayman, "Community Blog: Proposal for Nano Node Network Optimizations", 2020. [Online]. Available: https://medium.com/nanocurrency/proposal-for-nano-node-network-optimizations-21003e79cdba
 


### PR DESCRIPTION
Repnode.org is no longer available as a reference.