### PR TITLE
Instructions for using docker userns-remap (non-root issue #2122)

### DIFF
--- a/docs/running-a-node/docker-management.md
+++ b/docs/running-a-node/docker-management.md
@@ -203,7 +203,7 @@ As of v20.0, the docker containers support the [--user=](https://docs.docker.com
 
 To maintain existing compatibility the Docker containers are being built with `USER ROOT` and `WORK_DIR /root`
 
-The problem with this is that a straigthforward setup using host's `ROOT` user as the default may lead to a security issue. For hardening it, we recommend using the [userns-remap](https://docs.docker.com/engine/security/userns-remap/) Docker feature. This will require some extra steps for the setup.
+The problem with this is that a straightforward setup using host's `ROOT` user as the default may lead to a security issue. For hardening it, we recommend using the [userns-remap](https://docs.docker.com/engine/security/userns-remap/) Docker feature. This will require some extra steps for the setup.
 
 * Use `dockerd --userns-remap="default"` or edit `/etc/docker/daemon.json`:
 

--- a/docs/running-a-node/docker-management.md
+++ b/docs/running-a-node/docker-management.md
@@ -166,6 +166,8 @@ services:
      - "127.0.0.1:7078:7078" #websocket to localhost only
     volumes:
      - "${NANO_HOST_DIR}:/root" #path to host directory
+    userns_mode: "host"  #for userns-remap feature
+
 ```
 
 ---
@@ -228,6 +230,7 @@ $ grep dockremap /etc/subgid
 
 dockremap:231072:65536
 ```
+
 * `dockremap` must have permissions to access `${NANO_HOST_DIR}`.
 
 In the event you wish to use the `--user=nanocurrency -w=/home/nanocurrency` flags the directory you mount should have permissions changed for uid:guid 1000:1000 using `sudo chown -R 1000:1000 <local_path>` and your mount flag will become `-v <local_path>:/home/nanocurrency`. There is no need for setting the `userns-remap` feature in this case.

--- a/docs/running-a-node/docker-management.md
+++ b/docs/running-a-node/docker-management.md
@@ -203,7 +203,7 @@ As of v20.0, the docker containers support the [--user=](https://docs.docker.com
 
 To maintain existing compatibility the Docker containers are being built with `USER ROOT` and `WORK_DIR /root`
 
-The problem with this is that a straigthforward setup using host's `ROOT` user as the default may lead to a security issue. For hardening it, we recomend using the [userns-remap](https://docs.docker.com/engine/security/userns-remap/) Docker feature. This will require some extra steps for the setup.
+The problem with this is that a straigthforward setup using host's `ROOT` user as the default may lead to a security issue. For hardening it, we recommend using the [userns-remap](https://docs.docker.com/engine/security/userns-remap/) Docker feature. This will require some extra steps for the setup.
 
 * Use `dockerd --userns-remap="default"` or edit `/etc/docker/daemon.json`:
 


### PR DESCRIPTION
This changes the Docker Management section for recommending the usage of docker userns-remap in order to prevent a straightforward setup of leading users to use docker with real root privileges.