### PR TITLE
Group input parameters in block_create documentation

### DIFF
--- a/docs/commands/rpc-protocol.md
+++ b/docs/commands/rpc-protocol.md
@@ -589,6 +589,22 @@ Parameters for state block:
 
 _version 19.0+_  
 Default "false". If "true", "block" in the response will contain a JSON subtree instead of a JSON string.
+ 
+**Optional "work"**
+
+Work value (16 hexadecimal digits string, 64 bit). Uses **work** value for block from external source  
+
+**Optional "version"**
+
+_version 21.0+_
+Work version string. Currently "work_1" is the default and only valid option. Only used if optional **work** is not given.
+
+**Optional "difficulty"**
+
+_version 21.0+_  
+Difficulty value (16 hexadecimal digits string, 64 bit). Uses **difficulty** value to generate work. Only used if optional **work** is not given.  
+
+If difficulty and work values are both not given, RPC processor tries to calculate difficulty for work generation based on ledger data: epoch from previous block or from link for receive subtype; block subtype from previous block balance.  
 
 **Examples**
 
@@ -610,22 +626,6 @@ Default "false". If "true", "block" in the response will contain a JSON subtree 
   }
 }
 ```  
- 
-**Optional "work"**
-
-Work value (16 hexadecimal digits string, 64 bit). Uses **work** value for block from external source  
-
-**Optional "version"**
-
-_version 21.0+_
-Work version string. Currently "work_1" is the default and only valid option. Only used if optional **work** is not given.
-
-**Optional "difficulty"**
-
-_version 21.0+_  
-Difficulty value (16 hexadecimal digits string, 64 bit). Uses **difficulty** value to generate work. Only used if optional **work** is not given.  
-
-If difficulty and work values are both not given, RPC processor tries to calculate difficulty for work generation based on ledger data: epoch from previous block or from link for receive subtype; block subtype from previous block balance.  
 
 ---
 


### PR DESCRIPTION
Some of the optional input parameters were listed after the example response thus making them look like response parameters.
Moved parameters up to the other input parameters