### PR TITLE
Change V22 link for Debian from http to https

### DIFF
--- a/docs/snippets/current-release-build-links.md
+++ b/docs/snippets/current-release-build-links.md
@@ -1,7 +1,7 @@
 | OS | Download link/command | Verification |
 |----|---------------|-|
 | Universal Linux | https://repo.nano.org/live/binaries/nano-node-V22.0-Linux.tar.bz2 | [SHA256 Checksum](https://repo.nano.org/live/binaries/nano-node-V22.0-Linux.tar.bz2.sha256) |
-| Debian | http://repo.nano.org/live/binaries/nano-node-V22.0-Linux.deb | [SHA256 Checksum](https://repo.nano.org/live/binaries/nano-node-V22.0-Linux.deb.sha256) |
+| Debian | https://repo.nano.org/live/binaries/nano-node-V22.0-Linux.deb | [SHA256 Checksum](https://repo.nano.org/live/binaries/nano-node-V22.0-Linux.deb.sha256) |
 | macOS | https://repo.nano.org/live/binaries/nano-node-V22.0-Darwin.dmg | [SHA256 Checksum](https://s3.us-east-2.amazonaws.com/repo.nano.org/live/binaries/nano-node-V22.0-Darwin.dmg.sha256) |
 | Windows (exe) | https://repo.nano.org/live/binaries/nano-node-V22.0-win64.exe | [SHA256 Checksum](https://repo.nano.org/live/binaries/nano-node-V22.0-win64.exe.sha256) |
 | Windows (zip) | https://repo.nano.org/live/binaries/nano-node-V22.0-win64.zip | [SHA256 Checksum](https://repo.nano.org/live/binaries/nano-node-V22.0-win64.zip.sha256) |


### PR DESCRIPTION
Release Notes for V22 contains a non-https link for the Debian release.
https://docs.nano.org/releases/release-v22-0/