### PR TITLE
Clarified RocksDB migration

### DIFF
--- a/docs/commands/command-line-interface.md
+++ b/docs/commands/command-line-interface.md
@@ -74,7 +74,7 @@ Derive public key and account number from `<key>`
 
 ### --migrate_database_lmdb_to_rocksdb
 _version 22.0+_  
-Deletes existing rocksdb subfolder if it exists and migrates the ledger from LMDB to RocksDB. Does not delete the data.ldb file afterwards. NOTE: config files must still be updated to [enable RocksDB](../running-a-node/ledger-management.md#enable-rocksdb) after database is migrated.
+Deletes existing rocksdb subfolder if it exists and migrates the ledger from LMDB to RocksDB. Does not delete the data.ldb file afterwards. NOTE: config files must still be updated to [enable RocksDB](../running-a-node/ledger-management.md#enable-rocksdb) after database is migrated. You must also stop the node using the `stop` RPC call.
 
 ### --network
 _version 19.0+_  

--- a/docs/commands/command-line-interface.md
+++ b/docs/commands/command-line-interface.md
@@ -74,7 +74,7 @@ Derive public key and account number from `<key>`
 
 ### --migrate_database_lmdb_to_rocksdb
 _version 22.0+_  
-Deletes existing rocksdb subfolder if it exists and migrates the ledger from LMDB to RocksDB. Does not delete the data.ldb file afterwards. NOTE: config files must still be updated to [enable RocksDB](../running-a-node/ledger-management.md#enable-rocksdb) after database is migrated. You must also stop the node using the `stop` RPC call.
+Deletes existing rocksdb subfolder if it exists and migrates the ledger from LMDB to RocksDB. Does not delete the data.ldb file afterwards. NOTE: config files must still be updated to [enable RocksDB](../running-a-node/ledger-management.md#enable-rocksdb) after database is migrated. You must also stop the node using the [`stop` RPC](#stop).
 
 ### --network
 _version 19.0+_  


### PR DESCRIPTION
Remind node owners to stop their node using the RPC stop call before migrating in order for a successful migration