### PR TITLE
Updates the usage description for the confirmation_height_clear argument

### DIFF
--- a/docs/commands/command-line-interface.md
+++ b/docs/commands/command-line-interface.md
@@ -36,8 +36,8 @@ _Valid for both nano_node and nano_wallet processes_
 Pass node configuration values. This takes precedence over any values in the configuration file. This option can be repeated multiple times.
 
 ### --confirmation_height_clear
-_version 19.0+_  
-Sets the confirmation heights of all accounts to 0. Optional `--account` to only reset a single account. Do not use while the node is running.
+_version 24.0+_  
+It requires the argument `--account` and sets the confirmation heights of the specified account to 0. It may also be passed the value `all` to reset all the accounts. Do not use while the node is running.
 
 ### --daemon
 Start node daemon. Since version 19.0, network and path will be output, similar to:

--- a/docs/commands/command-line-interface.md
+++ b/docs/commands/command-line-interface.md
@@ -39,6 +39,9 @@ Pass node configuration values. This takes precedence over any values in the con
 _version 24.0+_  
 It requires the argument `--account` and sets the confirmation heights of the specified account to 0. It may also be passed the value `all` to reset all the accounts. Do not use while the node is running.
 
+_since version 19.0 up to 23.3_  
+Sets the confirmation heights of all accounts to 0. Optional `--account` to only reset a single account. Do not use while the node is running.
+
 ### --daemon
 Start node daemon. Since version 19.0, network and path will be output, similar to:
 ```


### PR DESCRIPTION
Addresses the changes made by the PR:
- https://github.com/nanocurrency/nano-node/pull/3836

This should be merged for v24.