### PR TITLE
Add documentation for the sideband info on confirmation websocket

### DIFF
--- a/docs/integration-guides/websockets.md
+++ b/docs/integration-guides/websockets.md
@@ -281,7 +281,7 @@ Including the election info option results in the following fields being include
 
 ###### Sideband info
 
-Sideband details for the confirmed blocks can be obtained by setting the `"include_sideband_info"` option to true:
+Since version 24.0 the sideband details for the confirmed blocks can be obtained by setting the `"include_sideband_info"` option to true:
 
 ```json
 {
@@ -295,8 +295,8 @@ Sideband details for the confirmed blocks can be obtained by setting the `"inclu
 
 The sideband fields when its option is set to true are:
 
-* `height`
-* `local_timestamp`
+* `height` is the block height
+* `local_timestamp` is the local time the block was inserted in to the ledger 
 
 ##### Sample Results
 

--- a/docs/integration-guides/websockets.md
+++ b/docs/integration-guides/websockets.md
@@ -279,6 +279,25 @@ Including the election info option results in the following fields being include
 * the confirmation `request_count` (_version 20.0+_)
 * number of blocks and voters (_version 21.0+_)
 
+###### Sideband info
+
+Sideband details for the confirmed blocks can be obtained by setting the `"include_sideband_info"` option to true:
+
+```json
+{
+  "action": "subscribe",
+  "topic": "confirmation",
+  "options": {
+    "include_sideband_info": "true"
+  }
+}
+```
+
+The sideband fields when its option is set to true are:
+
+* `height`
+* `local_timestamp`
+
 ##### Sample Results
 
 !!! note "Differences from the HTTP callback"


### PR DESCRIPTION
Document the sideband information websocket option, of the confirmation topic, added by:
- https://github.com/nanocurrency/nano-node/pull/3698