### PR TITLE
Add V25.0 build links for test network

### DIFF
--- a/docs/snippets/current-build-links-test.md
+++ b/docs/snippets/current-build-links-test.md
@@ -1,9 +1,9 @@
-| OS              | Download link/command                                             |
-|-----------------|-------------------------------------------------------------------|
-| Universal Linux | https://repo.nano.org/test/binaries/nano-node-V24.0-Linux.tar.bz2 |
-| Debian          | https://repo.nano.org/test/binaries/nano-node-V24.0-Linux.deb     |
-| macOS           | https://repo.nano.org/test/binaries/nano-node-V24.0-Darwin.dmg    |
-| Windows (exe)   | https://repo.nano.org/test/binaries/nano-node-V24.0-win64.exe     |
-| Windows (zip)   | https://repo.nano.org/test/binaries/nano-node-V24.0-win64.zip     |
-| Docker          | `docker pull nanocurrency/nano-test:V24.0`                        |
-| RHEL/CentOS rpm | Not available for the test network                                |
+| OS                  | Download link/command                                                                                     |
+|---------------------|-----------------------------------------------------------------------------------------------------------|
+| Universal Linux     | https://repo.nano.org/test/binaries/nano-node-V25.0-Linux.tar.bz2                                         |
+| Debian              | https://repo.nano.org/test/binaries/nano-node-V25.0-Linux.deb                                             |
+| macOS               | https://repo.nano.org/test/binaries/nano-node-V25.0-Darwin.dmg                                            |
+| Windows (exe)       | V25.0 is not available yet. Link for V24.0: https://repo.nano.org/test/binaries/nano-node-V24.0-win64.exe |
+| Windows (zip)       | V25.0 is not available yet. Link for V24.0: https://repo.nano.org/test/binaries/nano-node-V24.0-win64.zip |
+| Docker              | `docker pull nanocurrency/nano-test:V25.0`                                                                |
+| RHEL/RockyLinux rpm | Not available for the test network                                                                        |


### PR DESCRIPTION
Note: there are no builds yet for Windows.