### PR TITLE
Mkdocs updates to allow community PRs to pass the build.yml check/workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,6 @@ jobs:
         with:
           python-version: 3.x
       - run: pip install -r requirements.txt
-      - run: pip install ${{ secrets.MKDOCS_RESOURCES }}
       - run: mkdocs build --strict
 
 env:

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -19,7 +19,6 @@ jobs:
           key: ${{ github.ref }}
           path: .cache
       - run: pip install -r requirements.txt
-      - run: pip install ${{ secrets.MKDOCS_RESOURCES }}
       - run: mkdocs gh-deploy --force
 env:
   GH_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,7 +18,6 @@ jobs:
           key: ${{ github.ref }}
           path: .cache
       - run: pip install -r requirements.txt
-      - run: pip install ${{ secrets.MKDOCS_RESOURCES }}
       - run: mkdocs gh-deploy --force
 env:
   GH_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/publish-docker-master.yml
+++ b/.github/workflows/publish-docker-master.yml
@@ -15,6 +15,6 @@ jobs:
       # Build and test Docker image
       - run: |
           echo ${{ secrets.GHCR_TOKEN }} | docker login ghcr.io -u nanocurrency --password-stdin
-          docker pull ghcr.io/nanocurrency/mkdocs-material-insiders:latest
+          docker pull ghcr.io/nanocurrency/mkdocs-material:latest
           docker build -t ghcr.io/nanocurrency/nano-docs:latest .
           docker push ghcr.io/nanocurrency/nano-docs:latest

--- a/.github/workflows/publish-docker-master.yml
+++ b/.github/workflows/publish-docker-master.yml
@@ -15,6 +15,6 @@ jobs:
       # Build and test Docker image
       - run: |
           echo ${{ secrets.GHCR_TOKEN }} | docker login ghcr.io -u nanocurrency --password-stdin
-          docker pull ghcr.io/nanocurrency/mkdocs-material-insiders:latest
+          docker pull squidfunk/mkdocs-material:latest
           docker build -t ghcr.io/nanocurrency/nano-docs:latest .
           docker push ghcr.io/nanocurrency/nano-docs:latest

--- a/.github/workflows/publish-docker-master.yml
+++ b/.github/workflows/publish-docker-master.yml
@@ -15,6 +15,6 @@ jobs:
       # Build and test Docker image
       - run: |
           echo ${{ secrets.GHCR_TOKEN }} | docker login ghcr.io -u nanocurrency --password-stdin
-          docker pull ghcr.io/nanocurrency/mkdocs-material:latest
+          docker pull ghcr.io/nanocurrency/mkdocs-material-insiders:latest
           docker build -t ghcr.io/nanocurrency/nano-docs:latest .
           docker push ghcr.io/nanocurrency/nano-docs:latest

--- a/.github/workflows/publish-docker-master.yml
+++ b/.github/workflows/publish-docker-master.yml
@@ -15,6 +15,6 @@ jobs:
       # Build and test Docker image
       - run: |
           echo ${{ secrets.GHCR_TOKEN }} | docker login ghcr.io -u nanocurrency --password-stdin
-          docker pull squidfunk/mkdocs-material:latest
+          docker pull squidfunk/mkdocs-material:9.4.10@sha256:01605a03397a654b74b9de3157f56915d1e075e2d3bd22fcf3fb82c443553c25
           docker build -t ghcr.io/nanocurrency/nano-docs:latest .
           docker push ghcr.io/nanocurrency/nano-docs:latest

--- a/.github/workflows/publish-docker-pr.yml
+++ b/.github/workflows/publish-docker-pr.yml
@@ -15,6 +15,6 @@ jobs:
       # Build and test Docker image
       - run: |
           echo ${{ secrets.GHCR_TOKEN }} | docker login ghcr.io -u nanocurrency --password-stdin
-          docker pull ghcr.io/nanocurrency/mkdocs-material:latest
+          docker pull ghcr.io/nanocurrency/mkdocs-material-insiders:latest
           docker build -t ghcr.io/nanocurrency/nano-docs:pr-${{ env.PR_NUMBER }} .
           docker push ghcr.io/nanocurrency/nano-docs:pr-${{ env.PR_NUMBER }}

--- a/.github/workflows/publish-docker-pr.yml
+++ b/.github/workflows/publish-docker-pr.yml
@@ -15,6 +15,6 @@ jobs:
       # Build and test Docker image
       - run: |
           echo ${{ secrets.GHCR_TOKEN }} | docker login ghcr.io -u nanocurrency --password-stdin
-          docker pull squidfunk/mkdocs-material:latest
+          docker pull squidfunk/mkdocs-material:9.4.10@sha256:01605a03397a654b74b9de3157f56915d1e075e2d3bd22fcf3fb82c443553c25
           docker build -t ghcr.io/nanocurrency/nano-docs:pr-${{ env.PR_NUMBER }} .
           docker push ghcr.io/nanocurrency/nano-docs:pr-${{ env.PR_NUMBER }}

--- a/.github/workflows/publish-docker-pr.yml
+++ b/.github/workflows/publish-docker-pr.yml
@@ -15,6 +15,6 @@ jobs:
       # Build and test Docker image
       - run: |
           echo ${{ secrets.GHCR_TOKEN }} | docker login ghcr.io -u nanocurrency --password-stdin
-          docker pull ghcr.io/nanocurrency/mkdocs-material-insiders:latest
+          docker pull squidfunk/mkdocs-material:latest
           docker build -t ghcr.io/nanocurrency/nano-docs:pr-${{ env.PR_NUMBER }} .
           docker push ghcr.io/nanocurrency/nano-docs:pr-${{ env.PR_NUMBER }}

--- a/.github/workflows/publish-docker-pr.yml
+++ b/.github/workflows/publish-docker-pr.yml
@@ -15,6 +15,6 @@ jobs:
       # Build and test Docker image
       - run: |
           echo ${{ secrets.GHCR_TOKEN }} | docker login ghcr.io -u nanocurrency --password-stdin
-          docker pull ghcr.io/nanocurrency/mkdocs-material-insiders:latest
+          docker pull ghcr.io/nanocurrency/mkdocs-material:latest
           docker build -t ghcr.io/nanocurrency/nano-docs:pr-${{ env.PR_NUMBER }} .
           docker push ghcr.io/nanocurrency/nano-docs:pr-${{ env.PR_NUMBER }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/nanocurrency/mkdocs-material-insiders:latest
+FROM squidfunk/mkdocs-material:latest
 
 # Set build directory
 #WORKDIR /docs

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM squidfunk/mkdocs-material:latest
+FROM squidfunk/mkdocs-material:9.4.10@sha256:01605a03397a654b74b9de3157f56915d1e075e2d3bd22fcf3fb82c443553c25
 
 # Set build directory
 #WORKDIR /docs

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/nanocurrency/mkdocs-material:latest
+FROM ghcr.io/nanocurrency/mkdocs-material-insiders:latest
 
 # Set build directory
 #WORKDIR /docs

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ FROM ghcr.io/nanocurrency/mkdocs-material-insiders:latest
 COPY ./ /docs
 
 RUN \
+  pip install --upgrade pip
   pip install -r /docs/requirements.txt
 
 # Set working directory

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/nanocurrency/mkdocs-material-insiders:latest
+FROM ghcr.io/nanocurrency/mkdocs-material:latest
 
 # Set build directory
 #WORKDIR /docs

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ FROM ghcr.io/nanocurrency/mkdocs-material-insiders:latest
 COPY ./ /docs
 
 RUN \
-  pip install --upgrade pip
+  pip install --upgrade pip && \
   pip install -r /docs/requirements.txt
 
 # Set working directory

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -121,7 +121,7 @@ markdown_extensions:
   - pymdownx.critic
   - pymdownx.details
   - pymdownx.emoji:
-      emoji_index: !!python/name:materialx.emoji.twemoji
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
       emoji_generator: !!python/name:pymdownx.emoji.to_svg
   - pymdownx.highlight
   - pymdownx.inlinehilite
@@ -191,9 +191,9 @@ plugins:
         separator: '[\s\-,:!=\[\]()"/]+|(?!\b)(?=[A-Z][a-z])|\.(?!\d)|&[lg]t;'
     - social:
         cards: !ENV [ PRODUCTION, FALSE ]
-        cards_color:
-            fill: "#20204c"
-            text: "#FFFFFF"
+        cards_layout_options:
+            background_color: "#20204c"
+            color: "#FFFFFF"
     - redirects:
         redirect_maps:
             'running-a-node/rocksdb-ledger-backend.md': 'running-a-node/ledger-management.md'

--- a/readme.md
+++ b/readme.md
@@ -35,12 +35,6 @@ Note that because a local volume isn't being mounted this pull request review ap
 
 Access the site at http://localhost:8000. This supports automatic rebuilding, so anytime changes are saved to the documentation or configuration, it will be rebuilt and refresh the page. Some search indexing may remain cache between builds.
 
-## Theme
-
-We sponsor the developer of this theme on GitHub ([@squidfunk](https://github.com/squidfunk)) in order to get access to special features of the [Insiders](https://squidfunk.github.io/mkdocs-material-insiders/) version. Our [@nano-infrastructure](https://github.com/nano-infrastructure) account has the permissions to the private repository for that Insiders theme and using a personal access token in the GitHub deployment workflow (set as a GitHub secret in this repository), the theme is pulled down as part of deployment.
-
-Those developing locally may not have access to some of the special features of this insider theme, but most changes done by external contributors do not need the special theme - changes are backwards compatible with the regular theme. If you need access to the Insiders theme please contact the Nano core team.
-
 ## Formatting and Organization Tips
 
 ## Title and description

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 # Direct dependencies
-mkdocs-material-extensions>=1.0
-mkdocs-redirects>=1.0.0
+mkdocs>=1.5
+mkdocs-material>=9.4
+mkdocs-material-extensions>=1.3
+mkdocs-redirects>=1.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # Direct dependencies
 mkdocs>=1.5
-mkdocs-material>=9.4
+mkdocs-material[imaging]>=9.4
 mkdocs-material-extensions>=1.3
 mkdocs-redirects>=1.2


### PR DESCRIPTION
This PR updates mkdocs to the latest standard version, resolves deprecated mkdocs config options (`materialx.emoji.twemoji` and `social.cards_color`), & allows the build workflow to run/pass for community PRs

The next/final step to allowing community PRs to pass the build checks (specifically the publish jobs) will probably be to update the Dockerfile & publish workflows to use a standard mkdocs image as well