### PR TITLE
Update deprecated mkdocs.yml options

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -121,7 +121,7 @@ markdown_extensions:
   - pymdownx.critic
   - pymdownx.details
   - pymdownx.emoji:
-      emoji_index: !!python/name:materialx.emoji.twemoji
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
       emoji_generator: !!python/name:pymdownx.emoji.to_svg
   - pymdownx.highlight
   - pymdownx.inlinehilite
@@ -191,9 +191,9 @@ plugins:
         separator: '[\s\-,:!=\[\]()"/]+|(?!\b)(?=[A-Z][a-z])|\.(?!\d)|&[lg]t;'
     - social:
         cards: !ENV [ PRODUCTION, FALSE ]
-        cards_color:
-            fill: "#20204c"
-            text: "#FFFFFF"
+        cards_layout_options:
+            background_color: "#20204c"
+            color: "#FFFFFF"
     - redirects:
         redirect_maps:
             'running-a-node/rocksdb-ledger-backend.md': 'running-a-node/ledger-management.md'


### PR DESCRIPTION
Fixing mkdocs build --strict issues:

INFO    -  DeprecationWarning: 'materialx.emoji.twemoji' is deprecated.
           Material emoji logic has been officially moved into mkdocs-material
           version 9.4. Please use Material's 'material.extensions.emoji.twemoji'
           as mkdocs_material_extensions is deprecated and will no longer be
           supported moving forward. This is the last release.

             File "/home/default/.local/lib/python3.10/site-packages/materialx/emoji.py", line 106, in twemoji
               return _patch_index(options)
             File "/home/default/.local/lib/python3.10/site-packages/materialx/emoji.py", line 59, in _deprecated_func
               warnings.warn(
WARNING -  Material emoji logic has been officially moved into mkdocs-material
           version 9.4. Please use Material's 'material.extensions.emoji.twemoji'
           as mkdocs_material_extensions is deprecated and will no longer be
           supported moving forward. This is the last release.
WARNING -  Config value 'plugins': Plugin 'material/social' option 'cards_color': Deprecated, use 'cards_layout_options.background_color' and 'cards_layout_options.color' with 'default' layout