### PR TITLE
Adjust the current-release-notes redirection to V26.1

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -205,5 +205,5 @@ plugins:
             'what-is-nano/exploring-more.md': 'what-is-nano/overview.md'
             'releases/roadmap.md': 'https://github.com/orgs/nanocurrency/projects/5'
             'releases/upcoming-features.md': 'https://github.com/orgs/nanocurrency/projects/5'
-            'releases/current-release-notes.md': 'releases/release-v25-1.md'
+            'releases/current-release-notes.md': 'releases/release-v26-1.md'
             'node-implementation/contributing.md': 'core-development/overview.md'


### PR DESCRIPTION
This should fix the page banner pointing to V25.1 instead of V26.1.