### PR TITLE
election_statistics rpc documentation

### DIFF
--- a/docs/commands/rpc-protocol.md
+++ b/docs/commands/rpc-protocol.md
@@ -1689,6 +1689,35 @@ Derive deterministic keypair from **seed** based on **index**
 
 ---
 
+### election_statistics  
+_version 27.0+_ 
+
+Returns the number of each election type, the maximum and average election age from Active Election Container (AEC).
+
+Values in `max_election_age` and `average_election_age` are in milliseconds.
+
+**Request:**
+```json
+{
+  "action": "election_statistics"
+}
+```  
+**Response sample:**
+```json
+{
+    "normal": "152",
+    "priority": "1",
+    "hinted": "0",
+    "optimistic": "19",
+    "total": "172",
+    "aec_utilization_percentage": "3.42",
+    "max_election_age": "5493",
+    "average_election_age": "421"
+}
+```
+
+---
+
 ### epoch_upgrade  
 _enable_control required, version 20.0+_ 
 


### PR DESCRIPTION
Adds documentation the new `election_statistics` rpc call for v27.
This documentation depends on this PR to be merged first:
https://github.com/nanocurrency/nano-node/pull/4549

