### PR TITLE
Xrb conversion rpc calls removed

### DIFF
--- a/docs/commands/rpc-protocol.md
+++ b/docs/commands/rpc-protocol.md
@@ -4613,6 +4613,12 @@ Note: Before v20, the sampling period was between 16 and 36 seconds.
 
 ---
 
+## Removed RPCs
+
+---
+
+#### Removed in _v28_
+
 ### krai_from_raw   
 Divide a raw amount down by the krai ratio.  
 
@@ -4724,10 +4730,6 @@ Multiply an rai amount by the rai ratio.
   "amount": "1000000000000000000000000"
 }
 ```
-
----
-
-## Removed RPCs
 
 ---
 


### PR DESCRIPTION
Updates the status of the following rpc from deprecated to removed:
    krai_from_raw
    krai_to_raw
    mrai_from_raw
    mrai_to_raw
    rai_from_raw
    rai_to_raw

Changed in this PR:
https://github.com/nanocurrency/nano-node/pull/4733