### PR TITLE
docs: add AI agent context (AGENTS.md / CLAUDE.md)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,27 @@
+# Agent instructions — nano-docs (docs.nano.org)
+
+The Nano developer documentation, built with **MkDocs (Material)**. Live at
+**docs.nano.org** (served by GitHub Pages from the built `site/`).
+
+Task tracking is **beads** — run `bd prime` first. Use `bd` for all tasks; do
+not create markdown TODO lists.
+
+## Make a change and ship it
+
+- Documentation content is Markdown under **`docs/`**; navigation and theme are
+  in `mkdocs.yml`. Edit those, then open a PR.
+- Build locally to check: `pip install -r requirements.txt && mkdocs build --strict`.
+- Publishing is via the workflows in `.github/workflows/` (mkdocs build →
+  published site). Check those files for the exact production trigger; the live
+  origin is GitHub Pages serving the generated `site/`.
+
+## Infra
+
+This site is static and not part of the Cloud Run stack, so it has minimal
+shared infra. For the overall nano.org topology see the **[shared infra map](https://github.com/nanocurrency/nano-org/blob/main/docs/agents/INFRA.md)**.
+
+## Agent-doc policy — IMPORTANT
+
+Only the built MkDocs `site/` (generated from `docs/`) is published. Keep this
+`AGENTS.md` and any agent material at the **repo root** — **never put agent
+docs inside `docs/`**, or MkDocs will publish them to docs.nano.org.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,4 @@
+# CLAUDE.md
+
+Instructions for this repo live in **[AGENTS.md](./AGENTS.md)** (shared by all
+agents). Run `bd prime` for task-tracking (beads) context.


### PR DESCRIPTION
## What

Adds standardized AI-agent context so people other than the original migrator can use agents to update this property (bead nano_site_move-s34.2).

- `AGENTS.md` — short, repo-specific: what this is, how to ship a change, gotchas.
- `CLAUDE.md` — pointer stub to `AGENTS.md`.
- Links to the shared infra map (`nano-org/docs/agents/INFRA.md`) instead of duplicating LB/cert/Cloud SQL/SA topology.

Agent docs are not web-served from this repo (only built/app routes are).

🤖 Generated with [Claude Code](https://claude.com/claude-code)