### PR TITLE
Strengthen CLAUDE.md breadcrumb to key docs/tasks

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,16 @@
-# CLAUDE.md
+# CLAUDE.md — nano-docs (docs.nano.org)
 
-Instructions for this repo live in **[AGENTS.md](./AGENTS.md)** (shared by all
-agents). Run `bd prime` for task-tracking (beads) context.
+Full instructions are in **[AGENTS.md](./AGENTS.md)** — read it first. Quick
+pointers so the right file is obvious:
+
+- **Editing the developer documentation** (the most common task): content is
+  Markdown under **`docs/`**; the navigation and theme are in `mkdocs.yml`. Edit
+  those, open a PR, merge to `main` → the built site publishes automatically.
+  Undo = revert the commit.
+- Build locally to check: `pip install -r requirements.txt && mkdocs build --strict`.
+- Overall topology → the shared infra map AGENTS.md links.
+
+Heads-up: only the built `site/` (generated from `docs/`) is published — **never
+put agent docs inside `docs/`** (see AGENTS.md, "agent-doc policy").
+
+Task tracking is **beads** — run `bd prime` first.


### PR DESCRIPTION
A fresh, unmodified Claude Code auto-loads `CLAUDE.md`. It was a bare "see AGENTS.md" stub; now it carries this repo's **most common task** and points at the substantial docs directly, so the deeper guidance is anchored to the auto-loaded top-level context instead of only discoverable by search. Includes the served-from-root caveat where relevant. Matches the pattern adopted in nano-org (#145) and hub-nano-org (#45).

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)